### PR TITLE
Fixing some small dspam oddities

### DIFF
--- a/roles/mailserver/files/etc_dspam_default.prefs
+++ b/roles/mailserver/files/etc_dspam_default.prefs
@@ -28,7 +28,7 @@ enableWhitelist=on
 statisticalSedation=5
 
 # Signature Location: message, headers, attachment
-signatureLocation=headers  # { message | headers } -> default:message
+signatureLocation=headers
 
 # Whitelist Threshold: the minimum number of innocent hits from a recipient to
 # be automatically whitelisted. Do not set this value too low!

--- a/roles/mailserver/files/etc_dspam_dspam.conf
+++ b/roles/mailserver/files/etc_dspam_dspam.conf
@@ -5,7 +5,7 @@
 #
 # DSPAM Home: Specifies the base directory to be used for DSPAM storage
 #
-Home /var/spool/dspam
+Home /decrypted-mail/dspam
 
 #
 # StorageDriver: Specifies the storage driver backend (library) to use.


### PR DESCRIPTION
The included /etc/dspam/dspam.conf file still had "Home" set to /var/spool/dspam. Since there's some sensitive info in the logs there, I figured it'd be best to change that directive to place stuff in /decrypted-mail/dspam (I figured this is where you originally intended, since you were creating the decrypted-mail/dspam folder already).

Second, there was a really strange bug with dspam, where it _always_ placed the DSPAM signature in the message body, even though the config file had signatureLocation set to 'headers'. Only way I was able to fix it was to remove the trailing comment from the signatureLocation line in /etc/dspam/default.prefs.

Let me know if there's anything to improve here :-)
