### PR TITLE
Adding bits for configuring mail aliases.

### DIFF
--- a/roles/mailserver/templates/mailserver.sql.j2
+++ b/roles/mailserver/templates/mailserver.sql.j2
@@ -38,3 +38,10 @@ INSERT INTO {{ mail_mysql_database }}.`virtual_domains` (`id`, `name`)
 INSERT INTO {{ mail_mysql_database }}.`virtual_users`  (`domain_id`, `password` , `email`)
 	VALUES ('{{ virtual_user.domain_pk_id }}', '{{ virtual_user.password_hash }}', '{{ virtual_user.address }}');
 {% endfor %}
+
+{% if mail_virtual_aliases is defined %}
+{% for virtual_alias in mail_virtual_aliases %}
+INSERT INTO {{ mail_mysql_database }}.`virtual_aliases` (`domain_id`, `source`, `destination`)
+    VALUES ('{{ virtual_alias.domain_pk_id }}', '{{ virtual_alias.source }}', '{{virtual_alias.destination }}');
+{% endfor %}
+{% endif %}

--- a/roles/mailserver/vars/main.yml
+++ b/roles/mailserver/vars/main.yml
@@ -17,3 +17,7 @@ mail_virtual_users:
   - address: TODO@TODO.com
     password_hash: TODO@TODO.com
     domain_pk_id: 2
+mail_virtual_aliases:
+  - source: postmaster@TODO.com
+    destination: TODO@TODO.com
+    domain_pk_id: 1


### PR DESCRIPTION
Put in a conditional clause in the mailserver mysql template to add virtual aliases if mail_virtual_aliases is defined. I also added an example in vars/main.yml with a slight suggestion that folks consider having a postmaster@ alias (since it's generally a good idea to have that address at your domain).
