### PR TITLE
User account creation fails on Debian 7.1

### DIFF
--- a/roles/common/tasks/users.yml
+++ b/roles/common/tasks/users.yml
@@ -1,2 +1,2 @@
 - name: Create main user account
-  user: name=${main_user_name} state=present shell=/usr/bin/zsh groups=${main_user_name},sudo,fuse
+  user: name=${main_user_name} state=present shell=/usr/bin/zsh groups=sudo,fuse


### PR DESCRIPTION
```
TASK: [Create main user account] **********************************************
failed: [vps1.lukecyca.com] => {"failed": true, "item": ""}
msg: Group luke does not exist

FATAL: all hosts have already failed -- aborting
```

Simply removing `${main_user_name}` from the list of groups seems to work. Debian creates a primary group with the same name as the user automatically.
