### PR TITLE
Fix invalid service state

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -32,7 +32,7 @@
     - restart ntp
 
 - name: Ensure ntpd is running and enabled
-  service: name=ntp state=running enabled=yes
+  service: name=ntp state=started enabled=yes
 
 - name: Disable default Apache site
   command: a2dissite default


### PR DESCRIPTION
According to [the docs](http://www.ansibleworks.com/docs/modules.html#service), `running` is not a valid value for the state parameter. Ansible silently accepts it and starts the service anyway, but was bouncing the service each time it runs.

I believe `started` is a more appropriate value.
