### PR TITLE
Tarsnap warns about leading /

### DIFF
--- a/roles/tarsnap/tasks/tarsnap.yml
+++ b/roles/tarsnap/tasks/tarsnap.yml
@@ -25,4 +25,4 @@
   file: state=directory path=/usr/tarsnap-cache
 
 - name: Install nightly Tarsnap cronjob
-  cron: name="Tarsnap backup" hour="3" minute="0" job="/usr/local/bin/tarsnap --cachedir /usr/tarsnap-cache --keyfile /root/tarsnap.key -c -f backup-`date +\%Y\%m\%d` /home /root /decrypted /var/www /var/log /var/lib/mysql > /dev/null"
+  cron: name="Tarsnap backup" hour="3" minute="0" job="/usr/local/bin/tarsnap --cachedir /usr/tarsnap-cache --keyfile /root/tarsnap.key -c -f backup-`date +\%Y\%m\%d` -C / home root decrypted var/www var/log var/lib/mysql > /dev/null"


### PR DESCRIPTION
```
tarsnap: Removing leading '/' from member names
```

After #33, I'm getting an email from cron every day to let me know the above warning.

I'm going to fix the `tarsnap` command so that it doesn't produce this warning.
