### PR TITLE
Apache vhost misconfiguration

### DIFF
--- a/roles/blog/templates/etc_apache2_sites-available_blog.j2
+++ b/roles/blog/templates/etc_apache2_sites-available_blog.j2
@@ -1,5 +1,3 @@
-NameVirtualHost *:80
-
 <VirtualHost *:80>
     ServerName {{ blog_domain }}
     ServerAlias www.{{ blog_domain }}
@@ -7,7 +5,6 @@ NameVirtualHost *:80
     Redirect / https://{{ blog_domain }}/
 </VirtualHost>
 
-NameVirtualHost *:443
 
 <VirtualHost *:443>
     ServerName {{ blog_domain }}

--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -13,3 +13,6 @@
 
 - name: Enable Apache SSL module
   command: a2enmod ssl creates=/etc/apache2/mods-enabled/ssl.load
+
+- name: Enable NameVirtualHost for HTTPS
+  lineinfile: dest=/etc/apache2/ports.conf regexp='^    NameVirtualHost \*:443' insertafter='^<IfModule mod_ssl.c>' line='    NameVirtualHost *:443'

--- a/roles/owncloud/templates/etc_apache2_sites-available_owncloud.j2
+++ b/roles/owncloud/templates/etc_apache2_sites-available_owncloud.j2
@@ -1,5 +1,3 @@
-NameVirtualHost *:443
-
 <VirtualHost *:443>
     ServerName {{ owncloud_domain }}
 


### PR DESCRIPTION
I get this warning when apache is started:

```
root@vps1:~# grep VirtualHost /var/log/apache2/error.log*
/var/log/apache2/error.log.1:[Sun Sep 29 07:43:37 2013] [warn]
    NameVirtualHost *:80 has no VirtualHosts
```

Reading http://wiki.apache.org/httpd/CommonMisconfigurations, I believe this is because we have `NameVirtualHost *:80` in both `/etc/apache2/ports.conf` as well as our blog vhost.
