### PR TITLE
Cron job to monitor RBL listings

### DIFF
--- a/roles/mailserver/tasks/checkrbl.yml
+++ b/roles/mailserver/tasks/checkrbl.yml
@@ -1,0 +1,9 @@
+- name: What is our IP address?
+  command: dig ${mail_server_hostname} +short
+  register: dig_command
+
+- name: Download check-rbl
+  get_url: url=https://raw.github.com/lukecyca/check-rbl/f6b222b0ca/check-rbl.pl dest=/opt/check-rbl.pl
+
+- name: Install nightly check-rbl cronjob
+  cron: name="check-rbl" hour="2" minute="0" job="perl /opt/check-rbl.pl -i ${dig_command.stdout}"

--- a/roles/mailserver/tasks/main.yml
+++ b/roles/mailserver/tasks/main.yml
@@ -3,3 +3,4 @@
 - include: opendkim.yml tags=opendkim
 - include: dspam.yml tags=dspam
 - include: solr.yml tags=solr
+- include: checkrbl.yml tags=checkrbl


### PR DESCRIPTION
Since I'm now running my own mail server, I want to know if my server's IP ends up on any prominent RBLs so I can, you know, [post an angrygram](http://pigeonsnest.co.uk/stuff/crapstuff/sorbs.html).

There are some free services online to do this:
- http://mxtoolbox.com
- http://www.rblmon.com

But since this is a relatively simple check, perhaps we should include a cron job that checks once a day. Here's a nice-looking script:
- https://github.com/DjinnS/check-rbl
