### PR TITLE
Don't open unused ports

### DIFF
--- a/roles/common/files/etc_ferm_ferm.conf
+++ b/roles/common/files/etc_ferm_ferm.conf
@@ -16,8 +16,8 @@ table filter {
         proto icmp icmp-type echo-request ACCEPT;
 
         # expose our services to the world:
-        # web, ssh, imap + ssl, smtp + ssl, jabber/xmpp, dns, znc
-        proto tcp dport (53 http https ssh smtp 993 465 5222 5223 5269 6697) ACCEPT;
+        # dns, web, ssh, imap + ssl, smtp + ssl, znc
+        proto tcp dport (53 http https ssh 993 465 6697) ACCEPT;
 
         # openvpn
         proto udp dport 1194 ACCEPT;


### PR DESCRIPTION
Sovereign does not currently use jabber/xmpp or insecure smtp.
