### PR TITLE
add(tarsnap): Script to rotate backups

### DIFF
--- a/roles/tarsnap/files/tarsnap.sh
+++ b/roles/tarsnap/files/tarsnap.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+# Tarsnap backup script
+# Written by Tim Bishop, 2009.
+
+# Directories to backup
+DIRS="/home /root /decrypted /var/www /var/lib/mysql"
+
+# Number of daily backups to keep
+DAILY=7
+
+# Number of weekly backups to keep
+WEEKLY=3
+# Which day to do weekly backups on
+# 1-7, Monday = 1
+WEEKLY_DAY=5
+
+# Number of monthly backups to keep
+MONTHLY=1
+# Which day to do monthly backups on
+# 01-31 (leading 0 is important)
+MONTHLY_DAY=01
+
+# Path to tarsnap
+#TARSNAP="/home/tdb/tarsnap/tarsnap.pl"
+TARSNAP="/usr/local/bin/tarsnap"
+
+# end of config
+
+# day of week: 1-7, monday = 1
+DOW=`date +%u`
+# day of month: 01-31
+DOM=`date +%d`
+# month of year: 01-12
+MOY=`date +%m`
+# year
+YEAR=`date +%Y`
+# time
+TIME=`date +%H%M%S`
+
+# Backup name
+if [ X"$DOM" = X"$MONTHLY_DAY" ]; then
+	# monthly backup
+	BACKUP="$YEAR$MOY$DOM-$TIME-monthly"
+elif [ X"$DOW" = X"$WEEKLY_DAY" ]; then
+	# weekly backup
+	BACKUP="$YEAR$MOY$DOM-$TIME-weekly"
+else
+	# daily backup
+	BACKUP="$YEAR$MOY$DOM-$TIME-daily"
+fi
+
+# Do backups
+for dir in $DIRS; do
+	# nasty bodge for my large /home :-)
+	EXTRA_FLAGS=
+	if [ X"$dir" = X"/home" ]; then
+		EXTRA_FLAGS="--lowmem"
+	fi
+
+	echo "==> create $BACKUP-$dir"
+	$TARSNAP $EXTRA_FLAGS -c -f $BACKUP-$dir $dir
+done
+
+# Backups done, time for cleaning up old archives
+
+# using tail to find archives to delete, but its
+# +n syntax is out by one from what we want to do
+# (also +0 == +1, so we're safe :-)
+DAILY=`expr $DAILY + 1`
+WEEKLY=`expr $WEEKLY + 1`
+MONTHLY=`expr $MONTHLY + 1`
+
+# Do deletes
+TMPFILE=/tmp/tarsnap.archives.$$
+$TARSNAP --list-archives > $TMPFILE
+for dir in $DIRS; do
+	for i in `grep -E "^[[:digit:]]{8}-[[:digit:]]{6}-daily-$dir" $TMPFILE | sort -rn | tail -n +$DAILY`; do
+		echo "==> delete $i"
+		$TARSNAP -d -f $i
+	done
+	for i in `grep -E "^[[:digit:]]{8}-[[:digit:]]{6}-weekly-$dir" $TMPFILE | sort -rn | tail -n +$WEEKLY`; do
+		echo "==> delete $i"
+		$TARSNAP -d -f $i
+	done
+	for i in `grep -E "^[[:digit:]]{8}-[[:digit:]]{6}-monthly-$dir" $TMPFILE | sort -rn | tail -n +$MONTHLY`; do
+		echo "==> delete $i"
+		$TARSNAP -d -f $i
+	done
+done
+rm $TMPFILE

--- a/roles/tarsnap/files/tarsnaprc
+++ b/roles/tarsnap/files/tarsnaprc
@@ -1,0 +1,5 @@
+keyfile /root/tarsnap.key
+cachedir /usr/tarsnap-cache
+exclude /usr/tarsnap-cache
+humanize-numbers
+

--- a/roles/tarsnap/tasks/tarsnap.yml
+++ b/roles/tarsnap/tasks/tarsnap.yml
@@ -24,5 +24,11 @@
 - name: Create Tarsnap cache directory
   file: state=directory path=/usr/tarsnap-cache
 
-- name: Install nightly Tarsnap cronjob
-  cron: name="Tarsnap backup" hour="3" minute="0" job="/usr/local/bin/tarsnap --cachedir /usr/tarsnap-cache --keyfile /root/tarsnap.key -c -f backup-`date +\%Y\%m\%d` -C / home root decrypted var/www var/log var/lib/mysql > /dev/null"
+- name: Install Tarsnap configuration file
+  copy: src=tarsnaprc dest=/root/.tarsnaprc mode="644"
+
+- name: Install Tarsnap backup handler script
+  copy: src=tarsnap.sh dest=/root/tarsnap.sh mode="755"
+
+- name: Install nightly Tarsnap-generations cronjob
+  cron: name="Tarsnap backup" hour="23" minute="0" job="sh /root/tarsnap.sh >> /var/log/tarsnap.log"


### PR DESCRIPTION
Add tasks to install script/tarsnap configuration file and a cronjob to run
the backup job
Number of hourly/daily/weekly/monthly backups kept can be configure from the
tarsnap.sh script

Thanks to this script, we don't use all the backups which save space on
tarsnap server and thus reduce the price to pay
