### PR TITLE
add(fail2ban): Add server IP address to ignore IP

### DIFF
--- a/roles/common/templates/etc_fail2ban_jail.local.j2
+++ b/roles/common/templates/etc_fail2ban_jail.local.j2
@@ -1,5 +1,5 @@
 [DEFAULT]
-ignoreip  = 127.0.0.1 TODO(server IP address)
+ignoreip  = 127.0.0.1 {{ server_ip_address }}
 bantime   = 86400
 destemail = {{ admin_email }}
 banaction = iptables-multiport

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -11,6 +11,7 @@
 # main_user_name: TODO
 # admin_email: TODO@TODO.com
 # encfs_password: TODO
+# server_ip_address: TODO
 
 # ircbouncer
 znc_version: 1.0


### PR DESCRIPTION
ignoreip field inside /etc/fail2ban/jail.local is populated with
server_ip_address variable
