### PR TITLE
fix(apticron): apticron emails are sent to root

### DIFF
--- a/roles/common/templates/apticron.conf.j2
+++ b/roles/common/templates/apticron.conf.j2
@@ -1,4 +1,4 @@
-EMAIL="{{ admin_email }}"
+EMAIL="root"
 
 NOTIFY_NO_UPDATE="0"
 


### PR DESCRIPTION
Instead of sending email to {{ admin_email }} we send them to root user.
These emails will be redirected to the appropriate user via
mail_virtual_aliases variables
