### PR TITLE
added SHA check for tarsnap

### DIFF
--- a/roles/tarsnap/tasks/tarsnap.yml
+++ b/roles/tarsnap/tasks/tarsnap.yml
@@ -5,9 +5,39 @@
     - zlib1g-dev
     - e2fslibs-dev
 
+- name: Download the current tarsnap code signing key
+  get_url:
+    url=https://www.tarsnap.com/tarsnap-signing-key.asc
+    dest=/root/tarsnap-signing-key.asc
+
+- name: Add the tarsnap code signing key to your list of keys
+  command:
+    gpg --import tarsnap-signing-key.asc
+    chdir=/root/
+    
+- name: Download tarsnap SHA file
+  get_url:
+    url="https://www.tarsnap.com/download/tarsnap-sigs-{{tarsnap_version}}.asc"
+    dest="/root/tarsnap-sigs-{{tarsnap_version}}.asc"
+    
+- name: Make the command that gets the current sha
+  template:
+    src=getSha.sh
+    dest=/root/getSha.sh
+    mode=0755
+    
+- name: get the SHA256sum for this tarsnap release
+  command:
+    ./getSha.sh
+    chdir=/root
+  register: tarsnap_sha
+  
 - name: Download Tarsnap source
-  get_url: url=https://www.tarsnap.com/download/tarsnap-autoconf-${tarsnap_version}.tgz dest=/root/tarsnap-autoconf-${tarsnap_version}.tgz
-  #sha256sum=14c0172afac47f5f7cbc58e6442a27a0755685711f9d1cec4195c4f457053811
+  get_url:
+    url="https://www.tarsnap.com/download/tarsnap-autoconf-{{tarsnap_version}}.tgz"
+    dest="/root/tarsnap-autoconf-{{tarsnap_version}}.tgz"
+    sha256sum={{tarsnap_sha.stdout_lines[0]}}
+    
 
 - name: Decompress Tarsnap source
   command: tar xzf /root/tarsnap-autoconf-${tarsnap_version}.tgz chdir=/root creates=/root/tarsnap-autoconf-${tarsnap_version}/COPYING

--- a/roles/tarsnap/templates/getSha.sh
+++ b/roles/tarsnap/templates/getSha.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+gpgResult=`gpg --decrypt tarsnap-sigs-{{tarsnap_version}}.asc`
+sha=${gpgResult#*=}
+echo $sha > /root/tarsnapSha
+echo $sha


### PR DESCRIPTION
I think the recommended way to use vars these days is the {{var}} idiom rather than the ${var} idiom, so I used that.  And I used some extra carriage returns to make it easier to read.  Of course "recommended" and "easier" are subjective so feel free to reformat as you see fit.

this should address issue #77 
