### PR TITLE
Disable ufw logging on Debian 7 (bug workaround)

### DIFF
--- a/roles/common/tasks/ufw.yml
+++ b/roles/common/tasks/ufw.yml
@@ -33,6 +33,12 @@
   # ignore error resulting from known bug on Debian 7
   failed_when: ufw_enable|failed and not ansible_lsb['codename'] == 'wheezy'
 
-- name: Enable ufw again (workaround for known bug in Debian 7)
+- name: Turn off ufw logging in Debian 7 (bug workaround)
+  command: ufw logging off
+  register: ufw_logging_off
+  when: "ufw_status.stdout.startswith('Status: inactive') and ansible_lsb['codename'] == 'wheezy'"
+  failed_when: not ufw_logging_off.stdout.startswith('Logging disabled')
+
+- name: Enable ufw again in Debian 7 (bug workaround)
   command: ufw --force enable
   when: "ufw_status.stdout.startswith('Status: inactive') and ansible_lsb['codename'] == 'wheezy'"


### PR DESCRIPTION
Ran into a failure on Debian 7. Disabling logging (as originally suggested) on Debian 7 solves the problem.
