### PR TITLE
Testing & CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python: "2.7"
+install:
+  - pip install ansible
+script:
+  - ansible-playbook --syntax-check -i hosts site.yml


### PR DESCRIPTION
I've been working on an automated build scheme for ansible using [Vagrant](http://www.vagrantup.com).

Following [this post](http://keyholesoftware.com/2012/12/05/building_vagrant_boxes_with_veewee_on_travis/), I've tried to get it working on [Travis CI](https://travis-ci.org), but I've had no luck. It seems that this method [no longer works](https://groups.google.com/forum/#!topic/travis-ci/x7WGHb89DlE).

You can see my work thus far at https://github.com/lukecyca/sovereign/.

At this point I'm looking for input or other ideas. If I can't get it working on Travis or a similar service, I'll likely stand up a private [Jenkins](http://jenkins-ci.org) instance and run it there.
