### PR TITLE
Updated the OpenVPN role so certificate expiration is handled correctly

### DIFF
--- a/roles/vpn/tasks/openvpn.yml
+++ b/roles/vpn/tasks/openvpn.yml
@@ -32,7 +32,7 @@
         mode=600
 
 - name: Generate CA certificate
-  command: openssl req -nodes -batch -new -x509 -key {{ openvpn_ca }}.key -out {{ openvpn_ca }}.crt -subj "{{ openssl_request_subject }}/CN=ca-certificate"
+  command: openssl req -nodes -batch -new -x509 -key {{ openvpn_ca }}.key -out {{ openvpn_ca }}.crt -days {{ openvpn_days_valid }} -subj "{{ openssl_request_subject }}/CN=ca-certificate"
            creates={{ openvpn_ca }}.crt
 
 - name: Generate the OpenSSL configuration that will be used for the Server certificate's req and ca commands
@@ -70,7 +70,7 @@
   with_items: openvpn_clients
 
 - name: Generate certificates for the clients
-  command: openssl x509 -CA {{ openvpn_ca }}.crt -CAkey {{ openvpn_ca }}.key -CAcreateserial -req -in {{ item }}.csr -out {{ item }}.crt
+  command: openssl x509 -CA {{ openvpn_ca }}.crt -CAkey {{ openvpn_ca }}.key -CAcreateserial -req -days {{ openvpn_days_valid }} -in {{ item }}.csr -out {{ item }}.crt
            chdir={{ openvpn_path }}
            creates={{ item }}.crt
   with_items: openvpn_clients

--- a/roles/vpn/templates/openssl-server-certificate.cnf.j2
+++ b/roles/vpn/templates/openssl-server-certificate.cnf.j2
@@ -17,7 +17,7 @@ RANDFILE = $dir/.rand
 
 x509_extensions = server
 
-default_days = 3650
+default_days = {{ openvpn_days_valid }}
 default_crl_days= 30
 default_md = sha256
 preserve = no

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -61,7 +61,8 @@ znc_version: 1.0
 tarsnap_version: 1.0.35
 
 # # vpn
-openvpn_key_country:  "US"
+openvpn_days_valid: "1825"
+openvpn_key_country: "US"
 openvpn_key_province: "California"
 openvpn_key_city: "Beverly Hills"
 openvpn_key_org: "ACME CORPORATION"

--- a/vars/user.yml
+++ b/vars/user.yml
@@ -61,6 +61,7 @@
 # tarsnap_version: 1.0.35
 
 # # vpn
+# openvpn_days_valid: "1825"
 # openvpn_key_country:  "US"
 # openvpn_key_province: "California"
 # openvpn_key_city: "Beverly Hills"


### PR DESCRIPTION
The number of days that a certificate will be considered valid is now a user-controlled variable and is set to five years by default. (Fixes Issue #87)
