### PR TITLE
Set permissions and owner on virtual mail domains

### DIFF
--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -13,11 +13,13 @@
 - name: Create vmail user
   user: name=vmail group=vmail state=present uid=5000 home=/decrypted
 
-- name: Ensure mail directories are in place
-  file: state=directory path=/decrypted/${item.name}/${item.primary_user} owner=vmail group=dovecot
+- name: Ensure mail domain directories are in place
+  file: state=directory path=/decrypted/${item.name} owner=vmail group=dovecot mode=770
   with_items:
     - ${mail_virtual_domains}
-  file: state=directory path=/decrypted/${item.name} owner=vmail group=dovecot mode=770
+
+- name: Ensure mail directories are in place
+  file: state=directory path=/decrypted/${item.name}/${item.primary_user} owner=vmail group=dovecot
   with_items:
     - ${mail_virtual_domains}
 


### PR DESCRIPTION
Without the owner being set to vmail and dovecot, when a virtual user
tries to access their mail account, dovecot throws an error that it does
not have permission to create the mail folder for the user.

With the owner and permissions being set the user's mail directory is
created and they can successfully sign in.
