### PR TITLE
Fix local tarsnap key path in readme

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -82,7 +82,7 @@ If you haven't already, "download and install Tarsnap":https://www.tarsnap.com/d
 
 Create a new machine key for your server:
 
-bc. tarsnap-keygen --keyfile roles/common/files/root_tarsnap.key --user me@example.com --machine example.com
+bc. tarsnap-keygen --keyfile roles/tarsnap/files/root_tarsnap.key --user me@example.com --machine example.com
 
 h3. 3. Prep the server
 


### PR DESCRIPTION
Turns out it should be in the tarsnap role, not common. :)
