### PR TITLE
Use gathered facts to determine the correct network interface in the OpenVPN role

### DIFF
--- a/roles/vpn/tasks/openvpn.yml
+++ b/roles/vpn/tasks/openvpn.yml
@@ -93,7 +93,7 @@
            creates={{ openvpn_dhparam }}
 
 - name: Copy rc.local with firewall and dnsmasq rules into place
-  copy: src=etc_rc.local dest=/etc/rc.local
+  template: src=etc_rc.local dest=/etc/rc.local
 
 - name: Enable IPv4 traffic forwarding
   sysctl: name=net.ipv4.ip_forward value=1
@@ -104,7 +104,7 @@
     - iptables -A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT
     - iptables -A FORWARD -s 10.8.0.0/24 -j ACCEPT
     - iptables -A FORWARD -j REJECT
-    - iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o eth0 -j MASQUERADE
+    - iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o {{ ansible_default_ipv4.interface }} -j MASQUERADE
 
 - name: Copy OpenVPN configuration file into place
   template: src=etc_openvpn_server.conf.j2 dest=/etc/openvpn/server.conf

--- a/roles/vpn/templates/etc_rc.local
+++ b/roles/vpn/templates/etc_rc.local
@@ -13,7 +13,7 @@
 iptables -A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -A FORWARD -s 10.8.0.0/24 -j ACCEPT
 iptables -A FORWARD -j REJECT
-iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o eth0 -j MASQUERADE
+iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o {{ ansible_default_ipv4.interface }} -j MASQUERADE
 
 /etc/init.d/dnsmasq restart
 


### PR DESCRIPTION
Some VPS providers do not use eth0 by default, which prevents the MASQUERADE iptables rule from being set properly. This can also be an issue on a dedicated server that has multiple network interfaces.
