### PR TITLE
ircbouncer: connect to default server (freenode) using ssl

### DIFF
--- a/roles/ircbouncer/templates/var_lib_znc_configs_znc.conf.j2
+++ b/roles/ircbouncer/templates/var_lib_znc_configs_znc.conf.j2
@@ -62,7 +62,7 @@ Version = 1.0
 		LoadModule = kickrejoin
 		LoadModule = nickserv
 		LoadModule = savebuff
-		Server = chat.freenode.net 6665
+		Server = chat.freenode.net +6667
 	</Network>
 
 	Pass = {{ irc_password_hash }}


### PR DESCRIPTION
Of course we should connect via ssl/tls to freenode.
