### PR TITLE
Add logwatch to the monitoring role to email daily log summaries

### DIFF
--- a/roles/monitoring/tasks/logwatch.yml
+++ b/roles/monitoring/tasks/logwatch.yml
@@ -1,0 +1,5 @@
+- name: Install logwatch
+  apt: pkg=logwatch state=installed
+
+- name: Configure logwatch to email {{ main_user_name }}@{{ domain }} daily
+  action: lineinfile dest=/etc/cron.daily/00logwatch regexp="^/usr/sbin/logwatch" line="/usr/sbin/logwatch --output mail --mailto {{ main_user_name }}@{{ domain }} --detail high" state=present create=yes

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -1,1 +1,2 @@
 - include: monit.yml tags=monit
+- include: logwatch.yml tags=logwatch


### PR DESCRIPTION
Based on a playbook from https://github.com/phred/5minbootstrap, this is part of the "first 5 minutes on a server" blog post suggestion. A daily summary of server events from logs are e-mailed to the main_user_name variable. 
