### PR TITLE
fix(mail): main_virtual_xx variables usage

### DIFF
--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -16,13 +16,11 @@
 
 - name: Ensure mail domain directories are in place
   file: state=directory path=/decrypted/{{ item.name }} owner=vmail group=dovecot mode=770
-  with_items:
-    - "{{ mail_virtual_domains }}"
+  with_items: mail_virtual_domains
 
 - name: Ensure mail directories are in place
   file: state=directory path=/decrypted/{{ item.name }}/{{ item.primary_user }} owner=vmail group=dovecot
-  with_items:
-    - "{{ mail_virtual_domains }}"
+  with_items: mail_virtual_domains
 
 - name: Copy dovecot.conf into place
   copy: src=etc_dovecot_dovecot.conf dest=/etc/dovecot/dovecot.conf

--- a/roles/mailserver/tasks/dspam.yml
+++ b/roles/mailserver/tasks/dspam.yml
@@ -31,6 +31,5 @@
 
 - name: Put sieve rules into each primary user directory
   copy: src=dot_dovecot.sieve dest=/decrypted/{{ item.name }}/{{ item.primary_user }}/.dovecot.sieve owner=vmail group=dovecot
-  with_items:
-    - "{{ mail_virtual_domains }}"
+  with_items: mail_virtual_domains
   notify: restart dovecot

--- a/roles/mailserver/tasks/opendkim.yml
+++ b/roles/mailserver/tasks/opendkim.yml
@@ -12,13 +12,11 @@
 
 - name: Create OpenDKIM key directories
   file: state=directory path=/etc/opendkim/keys/{{ item.name }} group=opendkim owner=opendkim
-  with_items:
-    - "{{ mail_virtual_domains }}"
+  with_items: mail_virtual_domains
 
 - name: Generate OpenDKIM keys
   command: opendkim-genkey -r -d {{ item.name }} -D /etc/opendkim/keys/{{ item.name }}/ creates=/etc/opendkim/keys/{{ item.name }}/default.private
-  with_items:
-    - "{{ mail_virtual_domains }}"
+  with_items: mail_virtual_domains
 
 - name: Put opendkim.conf into place
   copy: src=etc_opendkim.conf dest=/etc/opendkim.conf owner=opendkim group=opendkim


### PR DESCRIPTION
mail_virtual_xx list were not use correctly in tasks.

We got error 'unicode object' has no attribute 'name' because:
with_items:
- "{{ mail_virtual_xx }}
  is understood has a list of strings containing information extracted from {{ mail_virtual_xx }} variable
  
  Now we use:
   with_items: virtual_domain_xx}}"
