### PR TITLE
Fix the Selfoss cron job

### DIFF
--- a/roles/news/tasks/selfoss.yml
+++ b/roles/news/tasks/selfoss.yml
@@ -35,4 +35,4 @@
   notify: restart apache
 
 - name: Install selfoss cronjob
-  cron: name="ownCloud" user="www-data" minute="*/5" job="curl -k 'https://{{ selfoss_domain }}/update'"
+  cron: name="selfoss" user="www-data" minute="*/5" job="curl -k 'https://{{ selfoss_domain }}/update' > /dev/null"


### PR DESCRIPTION
Currently, the selfoss cron job overrides the ownCloud cronjob and creates cron email noise. This commit fixes it.
