### PR TITLE
Silence the selfoss cron job

### DIFF
--- a/roles/news/tasks/selfoss.yml
+++ b/roles/news/tasks/selfoss.yml
@@ -35,4 +35,4 @@
   notify: restart apache
 
 - name: Install selfoss cronjob
-  cron: name="selfoss" user="www-data" minute="*/5" job="curl -k 'https://{{ selfoss_domain }}/update' > /dev/null"
+  cron: name="selfoss" user="www-data" minute="*/5" job="curl --silent --show-error -k 'https://{{ selfoss_domain }}/update' > /dev/null"


### PR DESCRIPTION
Curl outputs a progress bar to stderr, so just redirecting the stdout to /dev/null doesn't stop the email. This adds `--silent --show-error` to curl as per https://github.com/al3x/sovereign/pull/117#issuecomment-31323349, which stops the emails.
