### PR TITLE
Update the APT cache after adding the ownCloud repo

### DIFF
--- a/roles/owncloud/tasks/owncloud.yml
+++ b/roles/owncloud/tasks/owncloud.yml
@@ -15,7 +15,7 @@
   apt_repository: repo='deb http://download.opensuse.org/repositories/isv:ownCloud:community/Debian_7.0/ /'
 
 - name: Install ownCloud from OpenSuSE repository
-  apt: pkg=owncloud
+  apt: pkg=owncloud update_cache=yes
 
 - name: Install PHP-APC
   apt: pkg=php-apc


### PR DESCRIPTION
My very first environment setup with vagrant failed when installing owncloud, this should fix it.
