### PR TITLE
Don't individually mail all fail2ban actions

### DIFF
--- a/roles/common/templates/etc_fail2ban_jail.local.j2
+++ b/roles/common/templates/etc_fail2ban_jail.local.j2
@@ -3,7 +3,7 @@ ignoreip  = 127.0.0.1 {{ ansible_default_ipv4.address }} {{ ' '.join(friendly_ne
 bantime   = 86400
 destemail = {{ admin_email }}
 banaction = iptables-multiport
-action    = %(action_mwl)s
+action    = %(action_)s
 
 # JAILS
 [ssh]


### PR DESCRIPTION
As configured, every ban against the main fail2ban jails (sshd, apache, postfix) is individually mailed to the `admin_email` address. Each jail is also enumerated in ten “stopped”/“started” emails whenever fail2ban is restarted. By using the `action_` shortcut instead of `action_mwl`, the `mail-whois-lines` action is not invoked and no individual email is sent.

As the bans are still logged, the results are rolled up into the Logwatch email instead, and sent once together with all the other Logwatch notices.

This is the change I made to address issue #98, but I'm no expert so there might be a better method.
