### PR TITLE
Enabled unattended-upgrades

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -28,6 +28,10 @@
     - apt-transport-https
     - python-software-properties
 
+- name: Install unattended upgrades (Debian/Ubuntu only)
+  apt: pkg=unattended-upgrades state=installed
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
 - name: Install ntp
   apt: pkg=ntp state=installed
 


### PR DESCRIPTION
This works on Debian/Ubuntu only.

There are similar packages for other distributions, but they still
need manual configuration. It seemed better to go for the common
denominator. unattended-upgrades is usually installed by default
anyway, so we are just reinforcing best practices.

Fixes #92
