### PR TITLE
added pop3s and imaps ports to fail2ban.

### DIFF
--- a/roles/common/templates/etc_fail2ban_jail.local.j2
+++ b/roles/common/templates/etc_fail2ban_jail.local.j2
@@ -27,7 +27,7 @@ maxretry = 1
 [dovecot-pop3imap]
 enabled = true
 filter = dovecot-pop3imap
-action = iptables-multiport[name=dovecot-pop3imap, port="pop3,imap", protocol=tcp]
+action = iptables-multiport[name=dovecot-pop3imap, port="pop3,imap,993,995", protocol=tcp]
 logpath = /var/log/maillog
 maxretry = 20
 findtime = 1200


### PR DESCRIPTION
Otherwise only pop and imap (un-secured) are blocked.
Which we don't use.
