### PR TITLE
Fixes issue #8

### DIFF
--- a/roles/mailserver/files/etc_postfix_maps_smtp_header_checks.pcre
+++ b/roles/mailserver/files/etc_postfix_maps_smtp_header_checks.pcre
@@ -1,0 +1,5 @@
+/^\s*(Received: from)[^\n]*(.*)/ REPLACE $1 [127.0.0.1] (localhost [127.0.0.1])$2
+/^\s*User-Agent/        IGNORE
+/^\s*X-Enigmail/        IGNORE
+/^\s*X-Mailer/          IGNORE
+/^\s*X-Originating-IP/  IGNORE

--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -8,6 +8,7 @@
     - postgresql-9.1
     - postfix-pgsql
     - python-psycopg2
+    - postfix-pcre
 
 - name: Set postgres password
   command: sudo -u {{ db_admin_username }} psql -d {{ db_admin_username }} -c "ALTER USER postgres with  password '{{ db_admin_password }}';"
@@ -24,6 +25,14 @@
 - name: Copy import.sql
   template: src=mailserver.sql.j2 dest=/etc/postfix/import.sql owner=root group=root mode=0600
   notify: import sql postfix
+
+- name: Create postfix maps directory
+  file: path=/etc/postfix/maps state=directory owner=root group=root
+  when: mail_header_privacy == 1
+
+- name: Copy smtp_header_checks.pcre
+  copy: src=etc_postfix_maps_smtp_header_checks.pcre dest=/etc/postfix/maps/smtp_header_checks.pcre owner=root group=root
+  when: mail_header_privacy == 1
 
 - name: Copy main.cf
   template: src=etc_postfix_main.cf.j2 dest=/etc/postfix/main.cf owner=root group=root

--- a/roles/mailserver/templates/etc_postfix_main.cf.j2
+++ b/roles/mailserver/templates/etc_postfix_main.cf.j2
@@ -110,3 +110,8 @@ postscreen_dnsbl_sites =
 postscreen_dnsbl_threshold = 3
 postscreen_dnsbl_action = enforce
 postscreen_greet_action = enforce
+
+{% if mail_header_privacy == 1 %}
+# Remove local client IP from headers
+smtp_header_checks = pcre:/etc/postfix/maps/smtp_header_checks.pcre
+{% endif %}

--- a/vars/testing.yml
+++ b/vars/testing.yml
@@ -41,6 +41,7 @@ mail_virtual_aliases:
   - source: "webmaster@{{ domain }}"
     destination: "{{ admin_email }}"
     domain_pk_id: 1
+mail_header_privacy: 1
 
 # z-push
 zpush_timezone: "America/New_York"  #Example: "America/New_York"

--- a/vars/user.yml
+++ b/vars/user.yml
@@ -46,6 +46,7 @@ mail_virtual_aliases:
   - source: "webmaster@{{ domain }}"
     destination: "{{ admin_email }}"
     domain_pk_id: 1
+mail_header_privacy: 1
 
 # z-push
 zpush_timezone: "TODO"  #Example: "America/New_York"


### PR DESCRIPTION
Fixes issue #8. Adds new variable mail_header_privacy, on by default.
Installs postfix-pcre unconditionally, and then copies the pcre file
over and adds the header check to main.cf based on the variable value.
“this header replacement works great, but it logs that the replacement
has been done, which means that you are storing this information,
unless you are anonymizing your logs”
