### PR TITLE
Update chat.freenode.net port to SSL-only

### DIFF
--- a/roles/ircbouncer/templates/var_lib_znc_configs_znc.conf.j2
+++ b/roles/ircbouncer/templates/var_lib_znc_configs_znc.conf.j2
@@ -62,7 +62,7 @@ Version = 1.0
 		LoadModule = kickrejoin
 		LoadModule = nickserv
 		LoadModule = savebuff
-		Server = chat.freenode.net +6667
+		Server = chat.freenode.net +6697
 	</Network>
 
 	Pass = {{ irc_password_hash }}


### PR DESCRIPTION
If we want to use SSL, I wasn’t able to connect to port 6667 so I had to change this to 6697 which is the SSL only port
