### PR TITLE
Tarsnap looking for PostgreSQL in the wrong place

### DIFF
--- a/roles/tarsnap/files/tarsnap.sh
+++ b/roles/tarsnap/files/tarsnap.sh
@@ -4,7 +4,7 @@
 # Written by Tim Bishop, 2009.
 
 # Directories to backup (relative to /)
-DIRS="home root decrypted var/www opt/postgresql/9.1/main"
+DIRS="home root decrypted var/www var/lib/postgresql/9.1/main"
 
 # Number of daily backups to keep
 DAILY=7


### PR DESCRIPTION
Following the instructions of using a Debian 7 image, PostgreSQL 9.1 is installed in /var/lib/postgresql not /opt/postgresql
