### PR TITLE
Making main user's shell configurable

### DIFF
--- a/roles/common/tasks/users.yml
+++ b/roles/common/tasks/users.yml
@@ -1,2 +1,2 @@
 - name: Create main user account
-  user: name={{ main_user_name }} state=present shell=/usr/bin/zsh groups=sudo,fuse
+  user: name={{ main_user_name }} state=present shell={{ main_user_shell }} groups=sudo,fuse

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -8,6 +8,7 @@
 # domain: (required)
 # main_user_name: (required)
 admin_email: "{{ main_user_name }}@{{ domain }}"
+main_user_shell: "/bin/bash"
 # encfs_password: (required)
 friendly_networks:
   - ""


### PR DESCRIPTION
Not everyone wants to use `zsh`.  

The way it's done is very (maybe too?) straightforward. Please give feedback on how to do it better, if this is not in line how something like this should be done.
