### PR TITLE
Allow # in mail_db_password

### DIFF
--- a/roles/mailserver/templates/etc_dovecot_dovecot-sql.conf.ext.j2
+++ b/roles/mailserver/templates/etc_dovecot_dovecot-sql.conf.ext.j2
@@ -63,7 +63,7 @@ driver = pgsql
 #   connect = host=sql.example.com dbname=virtual user=virtual password=blarg
 #   connect = /etc/dovecot/authdb.sqlite
 #
-connect = host=127.0.0.1 dbname={{ mail_db_database }} user={{ mail_db_username }} password={{ mail_db_password }}
+connect = "host=127.0.0.1 dbname={{ mail_db_database }} user={{ mail_db_username }} password={{ mail_db_password }}"
 
 # Default password scheme.
 #


### PR DESCRIPTION
I had a `#` in my mail_db_password and spent the last 2 hours trying to figure out why I couldn't connect by IMAP. A `#` is only allowed if the connect string is wrapped in quotes. This will probably save a few people a lot of frustration by wrapping it in quotes to begin with.
