### PR TITLE
quote password environment variable

### DIFF
--- a/roles/mailserver/handlers/main.yml
+++ b/roles/mailserver/handlers/main.yml
@@ -11,6 +11,5 @@
   service: name=tomcat6 state=restarted
 
 - name: import sql postfix
-  action: shell PGPASSWORD={{ mail_db_password }} psql -h localhost -d {{ mail_db_database }} -U {{ mail_db_username }} -f /etc/postfix/import.sql --set ON_ERROR_STOP=1
+  action: shell PGPASSWORD='{{ mail_db_password }}' psql -h localhost -d {{ mail_db_database }} -U {{ mail_db_username }} -f /etc/postfix/import.sql --set ON_ERROR_STOP=1
   notify: restart postfix
-


### PR DESCRIPTION
...  in case it contains shell metacharacters.

I dunno how stupid I'm being here, but my password generator happily generates passwords containing `$` and `>` and othersuch.  My sovereign install was dying on `[mailserver | import sql postfix]` and this fixed it.  Thought it might help anybody else who got stuck the same way.
