### PR TITLE
Quote password variables (they may contain spaces)

### DIFF
--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -15,11 +15,11 @@
   notify: import sql postfix
 
 - name: Create database user for mail server
-  postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password={{ db_admin_password }} name={{ mail_db_username }} password={{ mail_db_password }} state=present
+  postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ mail_db_username }} password="{{ mail_db_password }}" state=present
   notify: import sql postfix
 
 - name: Create database for mail server
-  postgresql_db: login_host=localhost login_user={{ db_admin_username }} login_password={{ db_admin_password }} name={{ mail_db_database }} state=present owner={{ mail_db_username }}
+  postgresql_db: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ mail_db_database }} state=present owner={{ mail_db_username }}
   notify: import sql postfix
 
 - name: Copy import.sql

--- a/roles/news/tasks/selfoss.yml
+++ b/roles/news/tasks/selfoss.yml
@@ -6,10 +6,10 @@
   action: file owner=www-data group=www-data path=/var/www/selfoss recurse=yes state=directory
 
 - name: Create database user for selfoss
-  postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password={{ db_admin_password }} name={{ selfoss_db_username }} password={{ selfoss_db_password }} state=present
+  postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ selfoss_db_username }} password="{{ selfoss_db_password }}" state=present
 
 - name: Create database for selfoss
-  postgresql_db: login_host=localhost login_user={{ db_admin_username }} login_password={{ db_admin_password }} name={{ selfoss_db_database }} state=present owner={{ selfoss_db_username }}
+  postgresql_db: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ selfoss_db_database }} state=present owner={{ selfoss_db_username }}
 
 - name: Install selfoss config.ini
   template: src=var_www_selfoss_config.ini.j2 dest=/var/www/selfoss/config.ini group=www-data owner=www-data

--- a/roles/owncloud/tasks/owncloud.yml
+++ b/roles/owncloud/tasks/owncloud.yml
@@ -3,10 +3,10 @@
 # as per http://www.debiantutorials.com/how-to-install-owncloud-on-wheezy/
 
 - name: Create database user for ownCloud
-  postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password={{ db_admin_password }} name={{ owncloud_db_username }} password={{ owncloud_db_password }} state=present
+  postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ owncloud_db_username }} password="{{ owncloud_db_password }}" state=present
 
 - name: Create database for ownCloud
-  postgresql_db: login_host=localhost login_user={{ db_admin_username }} login_password={{ db_admin_password }} name={{ owncloud_db_database }} state=present owner={{ owncloud_db_username }}
+  postgresql_db: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ owncloud_db_database }} state=present owner={{ owncloud_db_username }}
 
 - name: Ensure repository key for ownCloud is in place
   apt_key: url=http://download.opensuse.org/repositories/isv:ownCloud:community/Debian_7.0/Release.key state=present

--- a/roles/xmpp/tasks/prosody.yml
+++ b/roles/xmpp/tasks/prosody.yml
@@ -18,5 +18,5 @@
   notify: restart prosody
 
 - name: Create Prosody accounts
-  command: prosodyctl register {{ item.name }} {{ prosody_virtual_domain }} {{ item.password }}
+  command: prosodyctl register {{ item.name }} {{ prosody_virtual_domain }} "{{ item.password }}"
   with_items: prosody_accounts


### PR DESCRIPTION
String-valued variables containing spaces can be substituted into an ansible
tasks file but they will not be interpreted correctly.
