### PR TITLE
Fix URL of z-push download

### DIFF
--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -8,7 +8,7 @@
     
 - name: Download z-push release
   get_url: 
-    url=http://zarafa-deutschland.de/z-push-download/final/2.1/z-push-{{ zpush_version }}.tar.gz
+    url=http://download.z-push.org/final/2.1/z-push-{{ zpush_version }}.tar.gz
     dest=/root/z-push-{{ zpush_version }}.tar.gz
 
 - name: Decompress z-push source


### PR DESCRIPTION
When trying to run the playbook to provision a Vagrant box locally I got an error when trying to unzip the downloaded z-push files. After some investigation it seems I was getting an HTML 302 response pointing to the new URL so this changes to the new URL scheme.
