### PR TITLE
Properly set the roundcube database password

### DIFF
--- a/roles/webmail/handlers/main.yml
+++ b/roles/webmail/handlers/main.yml
@@ -1,5 +1,9 @@
 - name: reconfigure roundcube db
-  action: shell dbconfig-generate-include /etc/dbconfig-common/roundcube.conf /etc/roundcube/debian-db.php
+  command: /usr/sbin/dbconfig-generate-include /etc/dbconfig-common/roundcube.conf /etc/roundcube/debian-db.php
+  notify: set roundcube password
+
+- name: set roundcube password
+  command: sudo -u {{ db_admin_username }} psql -d {{ webmail_db_database }} -c "ALTER USER {{ webmail_db_username }} with password '{{ webmail_db_password }}';"
   notify: import sql carddav
 
 - name: import sql carddav

--- a/roles/webmail/tasks/roundcube.yml
+++ b/roles/webmail/tasks/roundcube.yml
@@ -17,20 +17,14 @@
 - name: Decompress carddav plugin source
   command: tar xzf carddav_{{ carddav_version }}.tar.gz chdir=/root creates=/root/rcmcarddav-carddav_{{ carddav_version }}
 
-- name: Create /usr/share/roundcube/plugins/carddav
-  file: state=directory path=/usr/share/roundcube/plugins/carddav
-
-- name: Copy carddav plugin files to /usr/share/roundcube/plugins/carddav
-  shell: cp -R rcmcarddav-carddav_{{ carddav_version }}/* /usr/share/roundcube/plugins/carddav/ chdir=/root
+- name: Move carddav plugin files to /usr/share/roundcube/plugins/carddav
+  command: mv rcmcarddav-carddav_{{ carddav_version }} /usr/share/roundcube/plugins/carddav chdir=/root creates=/usr/share/roundcube/plugins/carddav
 
 - name: Link carddav plugin into /var/lib/roundcube/plugins
   file: state=link src=/usr/share/roundcube/plugins/carddav dest=/var/lib/roundcube/plugins/carddav force=yes
 
 - name: Remove downloaded carddav plugin file
   file: state=absent path=/root/carddav_{{ carddav_version }}.tar.gz
-
-- name: Remove extracted carddav plugin files
-  file: state=absent path=/root/rcmcarddav-carddav_{{ carddav_version }} recurse=true
 
 - name: Configure the Apache HTTP server for roundcube
   template: src=etc_apache2_sites-available_roundcube.j2 dest=/etc/apache2/sites-available/roundcube group=www-data owner=www-data force=yes


### PR DESCRIPTION
After much trial and error, this should properly set the "roundcube" database password to "testPassword" when running these playbooks within vagrant.   Previously, what I think was happening, was when dbconfig-common gets installed, it generates a random password for roundcube and sets it within postgres.  So when the handler to add the carddav database tables was attempted to be executed, it would fail.

This now properly sets the roundcube database password to {{ webmail_db_password }}
