### PR TITLE
Change loglevel to error

### DIFF
--- a/roles/mailserver/templates/usr_share_z-push_config.php.j2
+++ b/roles/mailserver/templates/usr_share_z-push_config.php.j2
@@ -86,7 +86,7 @@
     define('LOGFILEDIR', '/var/log/z-push/');
     define('LOGFILE', LOGFILEDIR . 'z-push.log');
     define('LOGERRORFILE', LOGFILEDIR . 'z-push-error.log');
-    define('LOGLEVEL', LOGLEVEL_INFO);
+    define('LOGLEVEL', LOGLEVEL_ERROR);
     define('LOGAUTHFAIL', false);
 
 


### PR DESCRIPTION
I would change the log level default to ERROR. My z-push log was over 17MB filled with [INFO] lines.
