### PR TITLE
Fix Google Authenticator file generation

### DIFF
--- a/roles/common/tasks/google_auth.yml
+++ b/roles/common/tasks/google_auth.yml
@@ -34,12 +34,11 @@
               insertbefore=BOF
               state=present
 
-- name: Generate a timed-based, no reuse, rate-limited (3 logins per 30 seconds) with no concurrently valid codes for default user
-  command: /usr/local/bin/google-authenticator -t -f -d --label="{{ main_user_name }}@{{ domain }}" --qr-mode=NONE -r 3 -R 30 -W --secret=/home/{{ main_user_name }}/.google_authenticator
+- name: Generate a timed-based, no reuse, rate-limited (3 logins per 30 seconds) with one concurrently valid code for default user
+  command: /usr/local/bin/google-authenticator -t -f -d --label="{{ main_user_name }}@{{ domain }}" --qr-mode=ANSI -r 3 -R 30 -w 1 --secret=/home/{{ main_user_name }}/.google_authenticator
            creates=/home/{{ main_user_name }}/.google_authenticator
-
-- name: Fix permissions on generated file
-  file: state=file path=/home/{{ main_user_name }}/.google_authenticator owner={{ main_user_name }} group={{ main_user_name }}
+  sudo: yes
+  sudo_user: "{{ main_user_name }}"
 
 - name: Retrieve generated keys from server
   fetch: src=/home/{{ main_user_name }}/.google_authenticator


### PR DESCRIPTION
The .google_authenticator file has to be generated by the user that is going to attempt to use it.  Also, -W doesn't seem to work (results an in INVALID_WINDOW error in /var/log/auth.log), so use -w 1 to allow for a single concurrent token.

Fixes #202 
