### PR TITLE
Skip the google authenticator generation if we're running as vagrant

### DIFF
--- a/roles/common/tasks/google_auth.yml
+++ b/roles/common/tasks/google_auth.yml
@@ -39,10 +39,13 @@
            creates=/home/{{ main_user_name }}/.google_authenticator
   sudo: yes
   sudo_user: "{{ main_user_name }}"
+  when: ansible_ssh_user != "vagrant"
 
 - name: Retrieve generated keys from server
   fetch: src=/home/{{ main_user_name }}/.google_authenticator
          dest=/tmp/sovereign-google-auth-files
+  when: ansible_ssh_user != "vagrant"
 
 - pause: seconds=5
          prompt="Your Google Authentication keys are in /tmp/sovereign-google-auth-files. Press any key to continue..."
+  when: ansible_ssh_user != "vagrant"


### PR DESCRIPTION
Vagrant can't sudo to the sovereign test user so this won't work.
