### PR TITLE
OpenVPN 2FA support

### DIFF
--- a/roles/vpn/files/etc_pam.d_openvpn
+++ b/roles/vpn/files/etc_pam.d_openvpn
@@ -1,0 +1,1 @@
+auth required pam_google_authenticator.so

--- a/roles/vpn/tasks/openvpn.yml
+++ b/roles/vpn/tasks/openvpn.yml
@@ -118,6 +118,10 @@
   copy: src=etc_dnsmasq.conf dest=/etc/dnsmasq.conf
   notify: restart dnsmasq
 
+- name: Copy OpenVPN PAM configuration file into place
+  copy: src=etc_pam.d_openvpn dest=/etc/pam.d/openvpn
+  notify: restart openvpn
+
 - name: Copy the ca.crt and ta.key files that clients will need in order to connect to the OpenVPN server
   command: cp {{ openvpn_path }}/{{ item[1] }} {{ openvpn_path }}/{{ item[0] }}
   with_nested:

--- a/roles/vpn/templates/client.cnf.j2
+++ b/roles/vpn/templates/client.cnf.j2
@@ -14,5 +14,9 @@ cert client.crt
 key client.key
 ns-cert-type server
 tls-auth ta.key 1
+
+# If you'd like to enable 2FA support, uncomment the following line
+;auth-user-pass
+
 comp-lzo
 verb 3

--- a/roles/vpn/templates/etc_openvpn_server.conf.j2
+++ b/roles/vpn/templates/etc_openvpn_server.conf.j2
@@ -31,6 +31,9 @@
 # open up this port on your firewall.
 port {{ openvpn_port }}
 
+# Uncomment the following line if you wish to enable PAM support for 2FA
+;plugin /usr/lib/openvpn/openvpn-auth-pam.so openvpn
+
 # TCP or UDP server?
 ;proto tcp
 proto {{ openvpn_protocol }}


### PR DESCRIPTION
Optional 2FA support for OpenVPN (requires uncommenting on the server and pushing new client configs)

Fixes #200
