### PR TITLE
Use libpam0g-dev instead of libpam-dev

### DIFF
--- a/roles/common/tasks/google_auth.yml
+++ b/roles/common/tasks/google_auth.yml
@@ -5,7 +5,7 @@
   apt: pkg={{ item }} state=present
   with_items:
     - libqrencode3
-    - libpam-dev
+    - libpam0g-dev
     #- libpam-google-authenticator    wasn't available in wheezy
 
 - name: Download Google authenticator pam module


### PR DESCRIPTION
libpam-dev didn't exist for some people so switching to libpam0g-dev instead.  This should fix the issue @nstanke was having on #199
