### PR TITLE
Update OpenVPN role to generate self-contained "unified" .ovpn profiles

### DIFF
--- a/roles/vpn/tasks/openvpn.yml
+++ b/roles/vpn/tasks/openvpn.yml
@@ -79,14 +79,39 @@
            creates=client.crt
   with_items: openvpn_clients
 
-- name: Create the client configs
-  template: src=client.cnf.j2
-            dest={{ openvpn_path }}/{{ item }}/{{ openvpn_server }}.ovpn
-  with_items: openvpn_clients
-
 - name: Generate HMAC firewall key
   command: openvpn --genkey --secret {{ openvpn_hmac_firewall }}
            creates={{ openvpn_hmac_firewall }}
+
+- name: Register CA certificate contents
+  command: cat ca.crt
+           chdir={{ openvpn_path }}
+  register: openvpn_ca_contents
+
+- name: Register client certificate contents
+  command: cat client.crt
+           chdir={{ openvpn_path }}/{{ item }}
+  with_items: openvpn_clients
+  register: openvpn_client_certificates
+
+- name: Register client key contents
+  command: cat client.key
+           chdir={{ openvpn_path }}/{{ item }}
+  with_items: openvpn_clients
+  register: openvpn_client_keys
+
+- name: Register HMAC firewall contents
+  command: cat ta.key
+           chdir={{ openvpn_path }}
+  register: openvpn_hmac_firewall_contents
+
+- name: Create the client configs
+  template: src=client.cnf.j2
+            dest={{ openvpn_path }}/{{ item[0] }}/{{ openvpn_server }}.ovpn
+  with_together:
+    - openvpn_clients
+    - openvpn_client_certificates.results
+    - openvpn_client_keys.results
 
 - name: Generate Diffie-Hellman parameters (this will take a while)
   command: openssl dhparam -out {{ openvpn_dhparam }} {{ openvpn_key_size }}

--- a/roles/vpn/templates/client.cnf.j2
+++ b/roles/vpn/templates/client.cnf.j2
@@ -8,15 +8,27 @@ resolv-retry infinite
 nobind
 persist-key
 persist-tun
-
-ca ca.crt
-cert client.crt
-key client.key
 ns-cert-type server
-tls-auth ta.key 1
+comp-lzo
+key-direction 1
+verb 3
+route {{ ansible_default_ipv4.address }} 255.255.255.255 net_gateway
 
 # If you'd like to enable 2FA support, uncomment the following line
 ;auth-user-pass
 
-comp-lzo
-verb 3
+<ca>
+{{ openvpn_ca_contents.stdout }}
+</ca>
+
+<cert>
+{{ item[1].stdout }}
+</cert>
+
+<key>
+{{ item[2].stdout }}
+</key>
+
+<tls-auth>
+{{ openvpn_hmac_firewall_contents.stdout }}
+</tls-auth>


### PR DESCRIPTION
- The role now generates .ovpn profiles with embedded CA, certificate, key, and HMAC firewall key information. These .ovpn profiles are compatible with OpenVPN for iOS and Android, and only a single file needs to be transferred to your mobile device.
- Added explicit route information to the .ovpn profile
