### PR TITLE
Make sure that only ZNC can read its certificate

### DIFF
--- a/roles/ircbouncer/tasks/znc.yml
+++ b/roles/ircbouncer/tasks/znc.yml
@@ -39,7 +39,7 @@
     /var/lib/znc/znc.pem creates=/var/lib/znc/znc.pem
 
 - name: Ensure znc user and group can read cert
-  file: path=/var/lib/znc/znc.pem group=znc owner=znc
+  file: path=/var/lib/znc/znc.pem group=znc owner=znc mode=640
 
 - name: Check for existing config file
   command: cat /var/lib/znc/configs/znc.conf


### PR DESCRIPTION
To bring this certificate in line with how those in ssl.yml are managed.
