### PR TITLE
Fix README to reflect changes in #176

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -98,7 +98,7 @@ If you haven't already, "download and install Tarsnap":https://www.tarsnap.com/d
 
 Create a new machine key for your server:
 
-bc. tarsnap-keygen --keyfile roles/tarsnap/files/root_tarsnap.key --user me@example.com --machine example.com
+bc. tarsnap-keygen --keyfile roles/tarsnap/files/decrypted_tarsnap.key --user me@example.com --machine example.com
 
 h3. 3. Prep the server
 


### PR DESCRIPTION
Change instructions for creating the tarsnap key to generate it at "decrypted_tarsnap.key" to catch up with PR #176.
