### PR TITLE
fixes deprecated autocreate plugin warning

### DIFF
--- a/roles/mailserver/files/etc_dovecot_conf.d_10-mail.conf
+++ b/roles/mailserver/files/etc_dovecot_conf.d_10-mail.conf
@@ -75,6 +75,32 @@ namespace inbox {
   # Namespace handles its own subscriptions. If set to "no", the parent
   # namespace handles them (empty prefix should always have this as "yes")
   #subscriptions = yes
+
+  # http://wiki2.dovecot.org/MailboxSettings
+  mailbox Drafts {
+    auto = subscribe
+    special_use = \Drafts
+  }
+
+  mailbox Sent {
+    auto = subscribe
+    special_use = \Sent
+  }
+
+  mailbox Junk {
+    auto = subscribe
+    special_use = \Junk
+  }
+
+  mailbox Trash {
+    auto = subscribe
+    special_use = \Trash
+  }
+
+  mailbox Archive {
+    auto = subscribe
+    special_use = \Archive
+  }
 }
 
 # Example shared namespace configuration

--- a/roles/mailserver/files/etc_dovecot_conf.d_20-imap.conf
+++ b/roles/mailserver/files/etc_dovecot_conf.d_20-imap.conf
@@ -13,7 +13,7 @@ protocol imap {
   #mail_max_userip_connections = 10
 
   # Space separated list of plugins to load (default is global mail_plugins).
-  mail_plugins = $mail_plugins antispam fts fts_solr autocreate
+  mail_plugins = $mail_plugins antispam fts fts_solr
 
   # IMAP logout format string:
   #  %i - total number of bytes read from client

--- a/roles/mailserver/files/etc_dovecot_conf.d_90-plugin.conf
+++ b/roles/mailserver/files/etc_dovecot_conf.d_90-plugin.conf
@@ -23,16 +23,4 @@ plugin {
   # FTS (full text search with Solr)
   fts = solr
   fts_solr = break-imap-search url=http://localhost:8080/solr/
-  
-  # Autocreate (specify mailboxes that must always exist for all users)
-  autocreate = Drafts
-  autocreate2 = Sent
-  autocreate3 = Junk
-  autocreate4 = Trash
-  autocreate5 = Archive
-  autosubscribe = Drafts
-  autosubscribe2 = Sent
-  autosubscribe3 = Junk
-  autosubscribe4 = Trash
-  autosubscribe5 = Archive
 }


### PR DESCRIPTION
Dovecot 2.x is issuing a warning that the autocreate plugin is deprecated, and to use mailbox { auto } setting instead.

http://wiki2.dovecot.org/MailboxSettings
