### PR TITLE
libpam-google-authenticator uses distribution package on Ubuntu 14.04

### DIFF
--- a/roles/common/tasks/google_auth_mod.yml
+++ b/roles/common/tasks/google_auth_mod.yml
@@ -1,0 +1,39 @@
+---
+# Defines tasks applicable for Google Authenticator
+# Ubuntu trusty version, uses standard libpam-google-authenticator package
+
+- name: Ensure required packages are installed
+  apt: pkg={{ item }} state=present
+  with_items:
+    - libqrencode3
+    - libpam0g-dev
+    - libpam-google-authenticator
+
+- name: Update sshd config to enable challenge responses
+  lineinfile: dest=/etc/ssh/sshd_config
+              regexp=^ChallengeResponseAuthentication
+              line="ChallengeResponseAuthentication yes"
+              state=present
+  notify: restart ssh
+
+- name: Add Google authenticator to PAM
+  lineinfile: dest=/etc/pam.d/sshd
+              line="auth required pam_google_authenticator.so"
+              insertbefore=BOF
+              state=present
+
+- name: Generate a timed-based, no reuse, rate-limited (3 logins per 30 seconds) with one concurrently valid code for default user
+  command: /usr/bin/google-authenticator -t -f -d --label="{{ main_user_name }}@{{ domain }}" --qr-mode=ANSI -r 3 -R 30 -w 1 --secret=/home/{{ main_user_name }}/.google_authenticator
+           creates=/home/{{ main_user_name }}/.google_authenticator
+  sudo: yes
+  sudo_user: "{{ main_user_name }}"
+  when: ansible_ssh_user != "vagrant"
+
+- name: Retrieve generated keys from server
+  fetch: src=/home/{{ main_user_name }}/.google_authenticator
+         dest=/tmp/sovereign-google-auth-files
+  when: ansible_ssh_user != "vagrant"
+
+- pause: seconds=5
+         prompt="Your Google Authentication keys are in /tmp/sovereign-google-auth-files. Press any key to continue..."
+  when: ansible_ssh_user != "vagrant"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -54,3 +54,6 @@
 - include: security.yml tags=security
 - include: ntp.yml tags=ntp
 - include: google_auth.yml tags=google_auth
+  when: ansible_distribution_release != 'trusty'
+- include: google_auth_mod.yml tags=google_auth
+  when: ansible_distribution_release == 'trusty'


### PR DESCRIPTION
No need to build it from source on Ubuntu trusty
