### PR TITLE
Update Vagrant base box for VMWare to fix error 404 on vagrant up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,9 +10,8 @@ Vagrant.configure('2') do |config|
   end
 
   config.vm.provider :vmware_fusion do |vbox, override|
-    override.vm.box = 'wheezy64'
-    # source: https://github.com/misheska/basebox-packer
-    override.vm.box_url = 'https://dl.dropboxusercontent.com/s/g8djjlz1x5tz30j/debian72.box?token_hash=AAH1_-tgqx5PabhxLXD-X7hFEZ9x_-a899fMAYI_Kgd4Bg&dl=1'
+    # source: https://vagrantcloud.com/box-cutter/debian75
+    override.vm.box = 'box-cutter/debian75'
     vbox.customize ["modifyvm", :id, "--memory", 512]
   end
 


### PR DESCRIPTION
Tried to follow the suggested [Development Environment setup](https://github.com/al3x/sovereign/wiki/Development-Environment) but got a 404 error (vagrant and vmware fusion on osx).
- The url in vagrantfile for the vmware_fusion compatible box has error 404.
- The commented source of that box leads to deprecated project, the repo's contents having been moved to https://github.com/box-cutter/debian-vm
- Vagrant boxes built with that new repo are now available on Vagrant Cloud, I used the one for 'Debian Wheezy 7.5 (64-bit)' https://vagrantcloud.com/box-cutter/debian75

For me Vagrant provision is now failing with a [github hostkey](https://github.com/al3x/sovereign/issues/261) issue but that seems entirely separate from the missing box error – so I haven't yet been able to run the sovereign tests...
