### PR TITLE
Fix monit ZNC monitoring

### DIFF
--- a/roles/monitoring/files/etc_monit_conf.d_znc
+++ b/roles/monitoring/files/etc_monit_conf.d_znc
@@ -2,7 +2,7 @@ check process znc with pidfile /var/run/znc/znc.pid
   group irc
   start program = "/etc/init.d/znc start"
   stop program = "/etc/init.d/znc stop"
-  if failed host localhost port 6697 type tcpSSL protocol http
+  if failed host localhost port 6643 protocol http
     with timeout 10 seconds
     then restart
   if 5 restarts within 5 cycles then timeout


### PR DESCRIPTION
When the ZNC web port changed in 8f4c9ea5f3ba46c24a1972266df5de01017e0129, it broke monit monitoring
