### PR TITLE
Vagrantfile improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,13 @@
 # https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md#130-september-5-2013
 
 Vagrant.configure('2') do |config|
-  # Source: https://vagrantcloud.com/box-cutter/debian75
+  # Debian 7 is the officially supported Linux distribution
   config.vm.box = 'box-cutter/debian75'
+
+  # Comment the entry above and uncomment one of these two entries
+  # below if you want to develop/test against Ubuntu 12.04/14.04.
+  # config.vm.box = 'box-cutter/ubuntu1204'
+  # config.vm.box = 'box-cutter/ubuntu1404'
 
   config.vm.provider :virtualbox do |v|
     v.memory = 512


### PR DESCRIPTION
This pull request contains a couple of improvements to the Vagrant configuration file such as using the same base box for both Virtualbox and VMware, adding references to Ubuntu base boxes (commented by default) and using shortcuts to configure VM memory.
