### PR TITLE
Add github public key to known_hosts.

### DIFF
--- a/roles/git/tasks/gitolite.yml
+++ b/roles/git/tasks/gitolite.yml
@@ -7,10 +7,20 @@
 - name: Add www-data to the git group
   user: name=www-data groups=git append=yes
 
+
+- name: Copy the github public key to known hosts
+  lineinfile:
+        dest=~/.ssh/known_hosts
+        regexp=^github.com
+        line="github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
+        state=present
+        create=yes
+
+
 - name: Download gitolite release
-  git: repo=git://github.com/sitaramc/gitolite
-       dest=/home/git/gitolite
-       version=v{{ gitolite_version }}
+  git:  repo=git://github.com/sitaramc/gitolite
+        dest=/home/git/gitolite
+        version=v{{ gitolite_version }}
 
 - name: Give git user file permissions
   file: path=/home/git/gitolite


### PR DESCRIPTION
This is in effect a fix for gitolite installation when ssh key forwarding is not configured/working, as per the error I reported here https://github.com/al3x/sovereign/issues/261

It adds githubs public key to the deploy user's known_hosts file prior to trying to clone gitolite from github.

cons:
- Public key is hard coded, this will break and require a change if github updates their key (but how often does that happen?)
- I'm not sure the gitolite role is the best place to add this, I'd do it as part of setting up the deploy user account, but sovereign currently does that manually...but it's where its currently needed to get the vagrant testing box up and running without manual intervention.
