### PR TITLE
Bump wallabag version to 1.7.1

### DIFF
--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -116,7 +116,7 @@ gitolite_version: 3.5.3.1
 newebe_domain: "newebe.{{ domain }}"
 
 # wallabag
-wallabag_version: 1.6.1b
+wallabag_version: 1.7.1
 wallabag_domain: "read.{{ domain }}"
 # wallabag_salt: (required)
 wallabag_db_username: wallabag


### PR DESCRIPTION
Wallabag 1.7.1 fixes a couple of security vulnerabilities, adds ePUB
export and more.

For a list of changes since 1.6.1b see:
- https://www.wallabag.org/blog/2014/05/29/1-7-epub-multi-users-available/
- https://www.wallabag.org/blog/2014/07/15/wallabag-1-7-1/
