### PR TITLE
Vagrantfile: Debian/Ubuntu + vagrant cachier multi-machine configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,22 @@
 # -*- mode: ruby -*-
-# If you're having issues, upgrade to Vagrant 1.3.x. It generates an inventory automatically:
-# https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md#130-september-5-2013
 
-Vagrant.configure('2') do |config|
-  # Debian 7 is the officially supported Linux distribution
-  config.vm.box = 'box-cutter/debian75'
+Vagrant.configure("2") do |config|
+  #
+  # Common Settings
+  #
 
-  # Comment the entry above and uncomment one of these two entries
-  # below if you want to develop/test against Ubuntu 12.04/14.04.
-  # config.vm.box = 'box-cutter/ubuntu1204'
-  # config.vm.box = 'box-cutter/ubuntu1404'
+  config.vm.hostname = "sovereign.local"
+  config.vm.network "private_network", ip: "172.16.100.2"
+
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "site.yml"
+    ansible.host_key_checking = false
+    ansible.extra_vars = { ansible_ssh_user: "vagrant", testing: true }
+
+    # ansible.tags = ["blog"]
+    # ansible.skip_tags = ["openvpn"]
+    # ansible.verbose = "vvvv"
+  end
 
   config.vm.provider :virtualbox do |v|
     v.memory = 512
@@ -19,18 +26,39 @@ Vagrant.configure('2') do |config|
     v.vmx["memsize"] = "512"
   end
 
-  config.vm.hostname = 'sovereign.local'
+  #
+  # vagrant-cachier
+  #
+  # Install the plugin by running: vagrant plugin install vagrant-cachier
+  # More information: https://github.com/fgrehm/vagrant-cachier
+  #
 
-  config.vm.network "private_network", ip: "172.16.100.2"
-
-  config.vm.provision :ansible do |ansible|
-    ansible.playbook = 'site.yml'
-    ansible.host_key_checking = false
-    ansible.extra_vars = { ansible_ssh_user: 'vagrant', testing: true }
-
-    # ansible.tags = ['blog']
-    # ansible.skip_tags = ['openvpn']
-    # ansible.verbose = 'vvvv'
+  if Vagrant.has_plugin? "vagrant-cachier"
+    config.cache.enable :apt
+    config.cache.scope = :box
   end
 
+  #
+  # Debian 7 64-bit (officially supported)
+  #
+
+  config.vm.define "debian", primary: true do |debian|
+    debian.vm.box = "box-cutter/debian75"
+  end
+
+  #
+  # Ubuntu 12.04 64-bit
+  #
+
+  config.vm.define "precise", autostart: false do |precise|
+    precise.vm.box = "box-cutter/ubuntu1204"
+  end
+
+  #
+  # Ubuntu 14.04 64-bit
+  #
+
+  config.vm.define "trusty", autostart: false do |trusty|
+    trusty.vm.box = "box-cutter/ubuntu1404"
+  end
 end


### PR DESCRIPTION
Update the Vagrantfile so that it is possible (and easier) to spin up Debian
7, Ubuntu 12.04 and Ubuntu 14.04 VMs. Although Vagrant allows spinning up all
of them simultaneously, there may be conflicts assigning host names and IP
addresses.

This Vagrantfile also enables the vagrant-cachier plugin (if installed) to
cache downloaded packages across subsequent runs of the same VM.

Running "vagrant up" will bring up only the Debian VM since it is the
officially supported Linux distributions. Ubuntu 12.04 and Ubuntu 14.04 must
be started explicitly by running either "vagrant up precise" or "vagrant up
trusty".
