### PR TITLE
Indicate how to make dovecot and znc password hashes in Python

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -140,9 +140,9 @@ Retype new password: foo
 
 Remove @{SHA512-CRYPT}@ and insert the rest as the @password_hash@ value.
 
-Alternatively, if you don't already have @doveadm@ installed, Python will generate the appropriate string for you (assuming your password is @password@):
+Alternatively, if you don't already have @doveadm@ installed, Python 3.3 or higher will generate the appropriate string for you on Unix-based platforms (assuming your password is @password@):
 
-bc. python3 -c 'import crypt; print(crypt.crypt("password"))'
+bc. python3 -c 'import crypt; print(crypt.crypt("password", salt=crypt.METHOD_SHA512))'
 
 Same for the IRC password hash...
 
@@ -154,9 +154,9 @@ bc. # znc --makepass
 
 Take the string beginning with @sha256#@ and insert it as the value for @irc_password_hash@.
 
-Alternatively, if you don't already have @znc@ installed, Python will generate the appropriate string for you:
+Alternatively, if you don't already have @znc@ installed, Python 3.3 or higher will generate the appropriate string for you on Unix-based platforms (assuming your password is @password@):
 
-bc. python3 -c 'import crypt; salt, hash = crypt.crypt("password", crypt.mksalt(crypt.METHOD_SHA256)).split("$")[2:]; print("sha256#{}#{}".format(hash, salt))'
+bc. python3 -c 'import crypt; print("sha256#{}#{}".format(*crypt.crypt("password", salt=crypt.METHOD_SHA256).split("$")[2:]))'
 
 For git hosting, copy your public key into place. @cp ~/.ssh/id_rsa.pub roles/git/files/gitolite.pub@ or similar.
 


### PR DESCRIPTION
Solves the chicken-or-the-egg problem of generating a dovecot and znc salted
password hash without already having dovecot and znc installed. That is, people
are installing sovereign typically do not have dovecot and znc installed and
have no way of generating the required salted password hashes.

Python 3 standard library generates SHA512-CRYPT salted password hashes by
default so it is particularly convenient for configuring dovecot:

```
python3 -c 'import crypt; print(crypt.crypt('password'))'
```

For ZNC, the required command is slightly more verbose.
