### PR TITLE
Newebe: improve playbook and don't fail on first installation

### DIFF
--- a/roles/newebe/handlers/main.yml
+++ b/roles/newebe/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart supervisor
+  service: name=supervisor state=restarted

--- a/roles/newebe/tasks/main.yml
+++ b/roles/newebe/tasks/main.yml
@@ -1,20 +1,19 @@
-- name: Install Python
-  apt: pkg=python,python-setuptools,python-pip,python-dev
-
-- name: Install Python tools
-  apt: pkg=python-imaging,python-pycurl
-
-- name: Install build tools
-  apt: pkg=build-essential,git
-
-- name: Install Python libs
-  apt: pkg=libxml2-dev,libxslt-dev,python-imaging
-
-- name: Install Supervisor
-  apt: pkg=supervisor
-
-- name: Install CouchDB
-  apt: pkg=couchdb
+- name: Install Dependencies
+  apt: pkg={{ item }}
+  with_items:
+    - build-essential
+    - couchdb
+    - git
+    - libxml2-dev
+    - libxslt-dev
+    - python
+    - python-dev
+    - python-imaging
+    - python-imaging
+    - python-pip
+    - python-pycurl
+    - python-setuptools
+    - supervisor
 
 - name: Install Newebe
   pip: name='git+https://github.com/gelnior/newebe.git#egg=newebe'
@@ -23,30 +22,30 @@
   group: name=newebe
 
 - name: Add user Newebe
-  user: name=newebe shell=/bin/bash groups=newebe
+  user: name=newebe groups=newebe shell=/usr/sbin/nologin
 
 - name: Create Newebe Config folder
-  file: path=/usr/local/etc/newebe/ 
-        owner=newebe 
-        group=newebe 
+  file: path=/usr/local/etc/newebe/
+        owner=newebe
+        group=newebe
         state=directory
 
 - name: Create Newebe folder
-  file: path=/usr/local/var/newebe/ 
-        owner=newebe 
-        group=newebe 
+  file: path=/usr/local/var/newebe/
+        owner=newebe
+        group=newebe
         state=directory
 
 - name: Create Newebe log folder
-  file: path=/usr/local/var/log/newebe/ 
-        owner=newebe 
-        group=newebe 
+  file: path=/usr/local/var/log/newebe/
+        owner=newebe
+        group=newebe
         state=directory
 
 - name: Set Newebe config file
   template: src=usr_local_etc_newebe_config.j2
-            dest=/usr/local/etc/newebe/config.yaml 
-            owner=newebe 
+            dest=/usr/local/etc/newebe/config.yaml
+            owner=newebe
             group=newebe
 
 - name: Set Supervisor config file
@@ -54,29 +53,25 @@
 
 - name: Set Newebe Supervisor config file
   copy: src=supervisor.conf dest=/etc/supervisor/supervisor.conf
+  notify: restart supervisor
 
-- name: Reload Supervisor and start Newebe
-  command: /usr/bin/supervisorctl update
+- name: Ensure Supervisor is running
+  service: name=supervisor state=running
 
 - name: Ensure that newebe is started
   supervisorctl: name=newebe state=started
 
 - name: Add mod_proxy module to Apache
-  raw: a2enmod proxy
-# When Ansible 1.6 will be available  
-# apache2_module: state=present name=proxy
+  apache2_module: state=present name=proxy
 
 - name: Add proxy_http module to Apache
-  raw: a2enmod proxy_http
-# When Ansible 1.6 will be available  
-# apache2_module: state=present name=proxy_http
-#
+  apache2_module: state=present name=proxy_http
 
 - name: Rename existing Apache newebe virtualhost
   command: mv /etc/apache2/sites-available/newebe /etc/apache2/sites-available/newebe.conf removes=/etc/apache2/sites-available/newebe
 
 - name: Remove old sites-enabled/newebe symlink (new one will be created by a2ensite)
-  command: rm /etc/apache2/sites-enabled/newebe removes=/etc/apache2/sites-enabled/newebe
+  file: path=/etc/apache2/sites-enabled/newebe state=absent
 
 - name: Configure the Apache HTTP server for Newebe
   template: src=etc_apache2_sites-available_newebe.j2
@@ -85,6 +80,5 @@
             owner=root
 
 - name: Enable the site
-  command: a2ensite newebe.conf
-           creates=/etc/apache2/sites-enabled/newebe.conf
+  command: a2ensite newebe.conf creates=/etc/apache2/sites-enabled/newebe.conf
   notify: restart apache

--- a/tests.py
+++ b/tests.py
@@ -127,6 +127,22 @@ class WebTests(unittest.TestCase):
             r.content
         )
 
+    def test_newebe_http(self):
+        """Newebe is displaying home page"""
+        r = requests.get('http://newebe.' + TEST_SERVER, verify=False)
+
+        # We should be redirected to https
+        self.assertEquals(r.history[0].status_code, 301)
+        self.assertEquals(r.url, 'https://newebe.' + TEST_SERVER + '/')
+
+        # 200 - We should be at the repository page
+        self.assertEquals(r.status_code, 200)
+        self.assertIn(
+            'Newebe, Freedom to Share',
+            r.content
+        )
+
+
 class IRCTests(unittest.TestCase):
     def test_irc_auth(self):
         """ZNC is accepting encrypted logins"""


### PR DESCRIPTION
- Add test
- Fixed Newebe's playbook failing on first run on a fresh Debian 7 VM
- Restart supervisord on changes
- Security: Use /usr/sbin/nologin as login shell for newebe user
- Speed: Consolidate all 'apt' entries into one
- Strip trailing whitespaces
- Update to take advantage of apache2_module from Ansible 1.6
- Use file path=... state=absent instead of "rm" command to delete files
