### PR TITLE
Install ZNC Monit config file only when needed

### DIFF
--- a/roles/ircbouncer/tasks/znc.yml
+++ b/roles/ircbouncer/tasks/znc.yml
@@ -63,7 +63,3 @@
 
 - name: Ensure znc is a system service
   service: name=znc state=started enabled=true
-
-- name: Copy monit service config files into place
-  copy: src=etc_monit_conf.d_znc dest=/etc/monit/conf.d/znc
-  notify: restart monit

--- a/roles/monitoring/README.md
+++ b/roles/monitoring/README.md
@@ -1,0 +1,2 @@
+This role should be enabled last in site.yml since it selectively installs configuration files
+based on the execution status of other roles before it.

--- a/roles/monitoring/tasks/monit.yml
+++ b/roles/monitoring/tasks/monit.yml
@@ -15,3 +15,12 @@
     - sshd
     - tomcat
   notify: restart monit
+
+- name: Determine if ZNC is installed
+  stat: path=/var/lib/znc/configs/znc.conf
+  register: znc_config_file
+
+- name: Copy ZNC monit service config files into place
+  copy: src=etc_monit_conf.d_znc dest=/etc/monit/conf.d/znc
+  notify: restart monit
+  when: znc_config_file.stat.exists == True

--- a/site.yml
+++ b/site.yml
@@ -16,7 +16,6 @@
     - blog
     - ircbouncer
     - xmpp
-    - monitoring
     - owncloud
     - vpn
     - tarsnap
@@ -24,3 +23,4 @@
     - git
     - newebe
     - readlater
+    - monitoring  # Monitoring role should be last. See roles/monitoring/README.md


### PR DESCRIPTION
This commit moves the monitoring role to the bottom of site.yml so that
it is executed after all other roles.

This is needed because the monitoring role conditionally installs Monit
configuration file based on whether some other packages have been
installed or not (such as ZNC).

This patch also adds a comment to the "monitoring" entry within the
"roles" list and a `roles/monitoring/README.md` file telling users why
the monitoring role has to come last.

Resolves #284
