### PR TITLE
Fixes newebe installation on Debian 7

### DIFF
--- a/roles/newebe/tasks/main.yml
+++ b/roles/newebe/tasks/main.yml
@@ -13,6 +13,7 @@
     - python-pip
     - python-pycurl
     - python-setuptools
+    - python-lxml
     - supervisor
 
 - name: Install Newebe


### PR DESCRIPTION
Installs python-lxml as a newebe dependency.

Related to issue #289 .
