### PR TITLE
ZNC: don't make install if configure or make fail

### DIFF
--- a/roles/ircbouncer/tasks/znc.yml
+++ b/roles/ircbouncer/tasks/znc.yml
@@ -23,7 +23,7 @@
   command: tar xzf /root/znc-{{ znc_version }}.tar.gz chdir=/root creates=/root/znc-{{ znc_version }}/configure
 
 - name: Build and install znc
-  shell: ./configure --enable-python ; make ; make install executable=/bin/bash chdir=/root/znc-{{ znc_version }} creates=/usr/local/bin/znc
+  shell: ./configure --enable-python && make && make install executable=/bin/bash chdir=/root/znc-{{ znc_version }} creates=/usr/local/bin/znc
   notify: restart znc
 
 - name: Create znc group


### PR DESCRIPTION
ZNC module compilation can fail on memory-limited systems, causing ZNC
to not work properly. But even after the failure, make install still
creates /usr/local/bin/znc. Thus Ansible would skip the ZNC build and
install step on future runs, despite ZNC not being correctly installed,
causing the playbook to appear to complete successfully and requiring
manual troubleshooting.
