### PR TITLE
Fix privilege error in monit tomcat6 config

### DIFF
--- a/roles/monitoring/files/etc_monit_conf.d_tomcat
+++ b/roles/monitoring/files/etc_monit_conf.d_tomcat
@@ -1,8 +1,6 @@
 check process tomcat with pidfile "/var/run/tomcat6.pid"
   group mail
   start program = "/etc/init.d/tomcat6 start"
-  as uid tomcat6 gid tomcat6
   stop program = "/etc/init.d/tomcat6 stop"
-  as uid tomcat6 gid tomcat6
   if failed port 8080 then alert
   if failed port 8080 for 5 cycles then restart


### PR DESCRIPTION
The tomcat6 user doesn't have the right privileges to run the
/etc/init.d/tomcat6 script.  Removing these lines allows monit to
restart tomcat if it stops for any reason, and makes the tomcat6 monit
config more consistent with other monit configs elsewhere.
