### PR TITLE
Allow znc timezone to be configured

### DIFF
--- a/roles/ircbouncer/templates/var_lib_znc_configs_znc.conf.j2
+++ b/roles/ircbouncer/templates/var_lib_znc_configs_znc.conf.j2
@@ -63,6 +63,7 @@ Version = 1.0
 	QuitMsg = {{ irc_quitmsg }}
 	RealName = {{ irc_realname }}
 	TimestampFormat = [%H:%M:%S]
+	Timezone = {{ irc_timezone }}
 
 	<Pass password>
 	        Method = sha256

--- a/vars/user.yml
+++ b/vars/user.yml
@@ -20,6 +20,7 @@ irc_realname: TODO
 irc_quitmsg: TODO
 irc_password_hash: TODO
 irc_password_salt: TODO
+irc_timezone: TODO      #Example: "America/New_York"
 
 # mailserver
 mail_db_password: TODO


### PR DESCRIPTION
Since 1.0, znc has allowed you to specify the user's timezone:
conveniently, in tzinfo format.  This allows the user to configure and
specify that timezone.

This matters because it affects the timestamps that znc issues when
playing back the buffer after a disconnection.

for more info see:
- http://wiki.znc.in/ChangeLog/1.0#Timezones
- http://wiki.znc.in/Configuration

There is also a zpush_timezone configuration option, which could at some
point be unified with irc_timezone into a common configuration item.
