### PR TITLE
Apache in Ubuntu 14.04 uses mod_gnutls.c

### DIFF
--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -18,4 +18,4 @@
   command: a2enmod ssl creates=/etc/apache2/mods-enabled/ssl.load
 
 - name: Enable NameVirtualHost for HTTPS
-  lineinfile: dest=/etc/apache2/ports.conf regexp='^    NameVirtualHost \*:443' insertafter='^<IfModule mod_ssl.c>' line='    NameVirtualHost *:443'
+  lineinfile: dest=/etc/apache2/ports.conf regexp='^        NameVirtualHost \*:443' insertafter='^<IfModule mod_(ssl|gnutls).c>' line='        NameVirtualHost *:443'


### PR DESCRIPTION
Currently the NamedVirtualHost line doesn't get added on Ubuntu because of the switch to mod_gnutls.c. 
Without this, you can't host multiple domains (with HTTPS) on the same site under Ubuntu (using SNI).
