### PR TITLE
Configure all Apache vhosts to disable SSLv3

### DIFF
--- a/roles/blog/templates/etc_apache2_sites-available_blog.j2
+++ b/roles/blog/templates/etc_apache2_sites-available_blog.j2
@@ -11,7 +11,7 @@
     ServerAlias www.{{ domain }}
 
     SSLEngine on
-    SSLProtocol ALL -SSLv2
+    SSLProtocol ALL -SSLv2 -SSLv3
     SSLHonorCipherOrder On
     SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AES:RSA+3DES:!ADH:!AECDH:!MD5:!DSS
     SSLCertificateFile      /etc/ssl/certs/wildcard_public_cert.crt

--- a/roles/git/templates/etc_apache2_sites-available_cgit.j2
+++ b/roles/git/templates/etc_apache2_sites-available_cgit.j2
@@ -8,7 +8,7 @@
     ServerName {{ cgit_domain }}
 
     SSLEngine on
-    SSLProtocol ALL -SSLv2
+    SSLProtocol ALL -SSLv2 -SSLv3
     SSLHonorCipherOrder On
     SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AES:RSA+3DES:!ADH:!AECDH:!MD5:!DSS
     SSLCertificateFile      /etc/ssl/certs/wildcard_public_cert.crt

--- a/roles/mailserver/templates/etc_apache2_sites-available_autoconfig.j2
+++ b/roles/mailserver/templates/etc_apache2_sites-available_autoconfig.j2
@@ -19,7 +19,7 @@
     ServerName {{ mail_server_autoconfig_hostname }}
 
     SSLEngine on
-    SSLProtocol ALL -SSLv2
+    SSLProtocol ALL -SSLv2 -SSLv3
     SSLHonorCipherOrder On
     SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AES:RSA+3DES:!ADH:!AECDH:!MD5:!DSS
     SSLCertificateFile      /etc/ssl/certs/wildcard_public_cert.crt

--- a/roles/newebe/templates/etc_apache2_sites-available_newebe.j2
+++ b/roles/newebe/templates/etc_apache2_sites-available_newebe.j2
@@ -9,7 +9,7 @@
     ServerName {{ newebe_domain }}
     SSLEngine On
 
-    SSLProtocol ALL -SSLv2
+    SSLProtocol ALL -SSLv2 -SSLv3
     SSLHonorCipherOrder On
     SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AES:RSA+3DES:!ADH:!AECDH:!MD5:!DSS
     SSLCertificateFile /etc/ssl/certs/wildcard_public_cert.crt

--- a/roles/news/templates/etc_apache2_sites-available_selfoss.j2
+++ b/roles/news/templates/etc_apache2_sites-available_selfoss.j2
@@ -8,7 +8,7 @@
     ServerName {{ selfoss_domain }}
 
     SSLEngine on
-    SSLProtocol ALL -SSLv2
+    SSLProtocol ALL -SSLv2 -SSLv3
     SSLHonorCipherOrder On
     SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AES:RSA+3DES:!ADH:!AECDH:!MD5:!DSS
     SSLCertificateFile      /etc/ssl/certs/wildcard_public_cert.crt

--- a/roles/owncloud/templates/etc_apache2_sites-available_owncloud.j2
+++ b/roles/owncloud/templates/etc_apache2_sites-available_owncloud.j2
@@ -8,7 +8,7 @@
     ServerName {{ owncloud_domain }}
 
     SSLEngine on
-    SSLProtocol ALL -SSLv2
+    SSLProtocol ALL -SSLv2 -SSLv3
     SSLHonorCipherOrder On
     SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AES:RSA+3DES:!ADH:!AECDH:!MD5:!DSS
     SSLCertificateFile      /etc/ssl/certs/wildcard_public_cert.crt

--- a/roles/readlater/templates/etc_apache2_sites-available_wallabag.j2
+++ b/roles/readlater/templates/etc_apache2_sites-available_wallabag.j2
@@ -8,7 +8,7 @@
     ServerName {{ wallabag_domain }}
 
     SSLEngine on
-    SSLProtocol ALL -SSLv2
+    SSLProtocol ALL -SSLv2 -SSLv3
     SSLHonorCipherOrder On
     SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AES:RSA+3DES:!ADH:!AECDH:!MD5:!DSS
     SSLCertificateFile      /etc/ssl/certs/wildcard_public_cert.crt

--- a/roles/webmail/templates/etc_apache2_sites-available_roundcube.j2
+++ b/roles/webmail/templates/etc_apache2_sites-available_roundcube.j2
@@ -8,7 +8,7 @@
     ServerName {{ webmail_domain }}
 
     SSLEngine on
-    SSLProtocol ALL -SSLv2
+    SSLProtocol ALL -SSLv2 -SSLv3
     SSLHonorCipherOrder On
     SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AES:RSA+3DES:!ADH:!AECDH:!MD5:!DSS
     SSLCertificateFile      /etc/ssl/certs/wildcard_public_cert.crt


### PR DESCRIPTION
In response to the POODLE SSL 3.0 exploit vulnerability released to the
public today
http://googleonlinesecurity.blogspot.com/2014/10/this-poodle-bites-exploiting-ssl-30.html
