### PR TITLE
Correct SMTP port number

### DIFF
--- a/roles/mailserver/templates/var_www_autoconfig_mail_config-v1.1.j2
+++ b/roles/mailserver/templates/var_www_autoconfig_mail_config-v1.1.j2
@@ -20,7 +20,7 @@
         </incomingServer>
         <outgoingServer type="smtp">
             <hostname>{{ mail_server_hostname }}</hostname>
-            <port>587</port>
+            <port>465</port>
             <socketType>SSL</socketType>
             <authentication>password-cleartext</authentication>
             <username>%EMAILADDRESS%</username>


### PR DESCRIPTION
Port 587 for smtp does not appear to match the mailserver configuration and leads to incorrect autoconfiguration.  Changed to 465 and tested with Icedove.
