### PR TITLE
Disable SSLv3 in Dovecot imap server

### DIFF
--- a/roles/mailserver/files/etc_dovecot_conf.d_10-ssl.conf
+++ b/roles/mailserver/files/etc_dovecot_conf.d_10-ssl.conf
@@ -41,7 +41,7 @@ ssl_key = </etc/ssl/private/wildcard_private.key
 #ssl_parameters_regenerate = 168
 
 # SSL protocols to use
-#ssl_protocols = !SSLv2
+ssl_protocols = !SSLv2 !SSLv3
 
 # SSL ciphers to use
 #ssl_cipher_list = ALL:!LOW:!SSLv2:!EXP:!aNULL


### PR DESCRIPTION
Disable SSLv3 in Dovecot imap server to avoid POODLE vulnerability
