### PR TITLE
Update dovecot version from wheezy backports

### DIFF
--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -3,7 +3,7 @@
   when: ansible_distribution_release == 'wheezy'
 
 - name: Install Dovecot and related packages on Debian 7
-  apt: pkg={{ item }} update_cache=yes state=installed default_release=wheezy-backports
+  apt: pkg={{ item }} update_cache=yes state=latest default_release=wheezy-backports
   with_items:
     - dovecot-core
     - dovecot-imapd


### PR DESCRIPTION
For correct implementation of the fix for logjam attack (https://github.com/sovereign/sovereign/pull/372), state=latest is needed to grab sufficient version of Dovecot. If not then https://github.com/neuhaus/sovereign/commit/37aa7e2cb5eb5cf89eb521080c96cd4b8bf4248e doesn't work.