### PR TITLE
Tagged 'deps' aptitude tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ To run just one or more piece, use tags. I try to tag all my includes for easy i
 
 You might find that it fails at one point or another. This is probably because something needs to be done manually, usually because there’s no good way of automating it. Fortunately, all the tasks are clearly named so you should be able to find out where it stopped. I’ve tried to add comments where manual intervention is necessary.
 
+The `deps` tag installs dependencies, the tagged tasks do not rely on the user settings (`vars/user.yml`).
+You might find that very convenient for cloud/Docker images.
+
 ### 6. Set up DNS
 
 If you’ve just bought a new domain name, point it at [Linode’s DNS Manager](https://library.linode.com/dns-manager) or similar. Most VPS services (and even some domain registrars) offer a managed DNS service that you can use for this at no charge. If you’re using an existing domain that’s already managed elsewhere, you can probably just modify a few records.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ To run just one or more piece, use tags. I try to tag all my includes for easy i
 
 You might find that it fails at one point or another. This is probably because something needs to be done manually, usually because there’s no good way of automating it. Fortunately, all the tasks are clearly named so you should be able to find out where it stopped. I’ve tried to add comments where manual intervention is necessary.
 
-The `deps` tag installs dependencies, the tagged tasks do not rely on the user settings (`vars/user.yml`).
+The `dependencies` tag installs dependencies, the tagged tasks do not rely on the user settings (`vars/user.yml`).
 You might find that very convenient for cloud/Docker images.
 
 ### 6. Set up DNS

--- a/roles/common/tasks/encfs.yml
+++ b/roles/common/tasks/encfs.yml
@@ -4,6 +4,8 @@
     - encfs
     - fuse
     - libfuse-dev
+  tags:
+    - deps
 
 - name: Create encrypted directory
   file: state=directory path=/encrypted

--- a/roles/common/tasks/encfs.yml
+++ b/roles/common/tasks/encfs.yml
@@ -5,7 +5,7 @@
     - fuse
     - libfuse-dev
   tags:
-    - deps
+    - dependencies
 
 - name: Create encrypted directory
   file: state=directory path=/encrypted

--- a/roles/common/tasks/google_auth.yml
+++ b/roles/common/tasks/google_auth.yml
@@ -7,6 +7,8 @@
     #- libpam-google-authenticator    wasn't available in wheezy
     - libpam0g-dev
     - libqrencode3
+  tags:
+    - deps
 
 - name: Download Google authenticator pam module
   get_url: url=https://google-authenticator.googlecode.com/files/libpam-google-authenticator-{{ google_auth_version }}-source.tar.bz2

--- a/roles/common/tasks/google_auth.yml
+++ b/roles/common/tasks/google_auth.yml
@@ -8,7 +8,7 @@
     - libpam0g-dev
     - libqrencode3
   tags:
-    - deps
+    - dependencies
 
 - name: Download Google authenticator pam module
   get_url: url=https://google-authenticator.googlecode.com/files/libpam-google-authenticator-{{ google_auth_version }}-source.tar.bz2

--- a/roles/common/tasks/google_auth_mod.yml
+++ b/roles/common/tasks/google_auth_mod.yml
@@ -9,7 +9,7 @@
     - libpam0g-dev
     - libqrencode3
   tags:
-    - deps
+    - dependencies
 
 - name: Update sshd config to enable challenge responses
   lineinfile: dest=/etc/ssh/sshd_config

--- a/roles/common/tasks/google_auth_mod.yml
+++ b/roles/common/tasks/google_auth_mod.yml
@@ -8,6 +8,8 @@
     - libpam-google-authenticator
     - libpam0g-dev
     - libqrencode3
+  tags:
+    - deps
 
 - name: Update sshd config to enable challenge responses
   lineinfile: dest=/etc/ssh/sshd_config

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -4,17 +4,17 @@
   template: src=apt_sources.list.j2 dest=/etc/apt/sources.list
   when: ansible_distribution == 'Ubuntu'
   tags:
-    - deps
+    - dependencies
 
 - name: Update apt cache
   apt: update_cache=yes
   tags:
-    - deps
+    - dependencies
 
 - name: Upgrade all safe packages
   apt: upgrade=safe
   tags:
-    - deps
+    - dependencies
 
 - name: Install necessities and nice-to-haves
   apt: pkg={{ item }} state=installed
@@ -39,7 +39,7 @@
     - vim
     - zsh
   tags:
-    - deps
+    - dependencies
 
 - name: Set timezone to UTC
   action: shell echo Etc/UTC > /etc/timezone

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -3,12 +3,18 @@
 - name: Set up closest mirror autoselect (ubuntu-only)
   template: src=apt_sources.list.j2 dest=/etc/apt/sources.list
   when: ansible_distribution == 'Ubuntu'
+  tags:
+    - deps
 
 - name: Update apt cache
   apt: update_cache=yes
+  tags:
+    - deps
 
 - name: Upgrade all safe packages
   apt: upgrade=safe
+  tags:
+    - deps
 
 - name: Install necessities and nice-to-haves
   apt: pkg={{ item }} state=installed
@@ -32,6 +38,8 @@
     - molly-guard
     - vim
     - zsh
+  tags:
+    - deps
 
 - name: Set timezone to UTC
   action: shell echo Etc/UTC > /etc/timezone

--- a/roles/common/tasks/ntp.yml
+++ b/roles/common/tasks/ntp.yml
@@ -4,7 +4,7 @@
 - name: Install ntp
   apt: pkg=ntp state=installed
   tags:
-    - deps
+    - dependencies
 
 - name: Configure ntp
   template: src=ntp.conf.j2 dest=/etc/ntp.conf

--- a/roles/common/tasks/ntp.yml
+++ b/roles/common/tasks/ntp.yml
@@ -3,6 +3,8 @@
 
 - name: Install ntp
   apt: pkg=ntp state=installed
+  tags:
+    - deps
 
 - name: Configure ntp
   template: src=ntp.conf.j2 dest=/etc/ntp.conf

--- a/roles/common/tasks/security.yml
+++ b/roles/common/tasks/security.yml
@@ -4,6 +4,8 @@
     - fail2ban
     - lynis
     - rkhunter
+  tags:
+    - deps
 
 - name: Copy fail2ban configuration into place
   template: src=etc_fail2ban_jail.local.j2 dest=/etc/fail2ban/jail.local

--- a/roles/common/tasks/security.yml
+++ b/roles/common/tasks/security.yml
@@ -5,7 +5,7 @@
     - lynis
     - rkhunter
   tags:
-    - deps
+    - dependencies
 
 - name: Copy fail2ban configuration into place
   template: src=etc_fail2ban_jail.local.j2 dest=/etc/fail2ban/jail.local

--- a/roles/common/tasks/ufw.yml
+++ b/roles/common/tasks/ufw.yml
@@ -4,6 +4,8 @@
 # ufw includes sensible icmp defaults
 - name: Install ufw
   apt: pkg=ufw state=present
+  tags:
+    - deps
 
 - name: Deny everything
   ufw: policy=deny

--- a/roles/common/tasks/ufw.yml
+++ b/roles/common/tasks/ufw.yml
@@ -5,7 +5,7 @@
 - name: Install ufw
   apt: pkg=ufw state=present
   tags:
-    - deps
+    - dependencies
 
 - name: Deny everything
   ufw: policy=deny

--- a/roles/git/tasks/cgit.yml
+++ b/roles/git/tasks/cgit.yml
@@ -5,6 +5,8 @@
     - groff
     - libssl-dev
     - python-pip
+  tags:
+    - deps
 
 - name: Install cgit pip dependencies
   pip: name={{ item }}

--- a/roles/git/tasks/cgit.yml
+++ b/roles/git/tasks/cgit.yml
@@ -6,7 +6,7 @@
     - libssl-dev
     - python-pip
   tags:
-    - deps
+    - dependencies
 
 - name: Install cgit pip dependencies
   pip: name={{ item }}

--- a/roles/git/tasks/gitolite_packaged.yml
+++ b/roles/git/tasks/gitolite_packaged.yml
@@ -9,6 +9,8 @@
 
 - name: Install gitolite3 package
   apt: pkg=gitolite3 state=installed
+  tags:
+    - deps
 
 - name: Copy .gitolite.rc file
   copy: src=home_git_.gitolite.rc

--- a/roles/git/tasks/gitolite_packaged.yml
+++ b/roles/git/tasks/gitolite_packaged.yml
@@ -10,7 +10,7 @@
 - name: Install gitolite3 package
   apt: pkg=gitolite3 state=installed
   tags:
-    - deps
+    - dependencies
 
 - name: Copy .gitolite.rc file
   copy: src=home_git_.gitolite.rc

--- a/roles/ircbouncer/tasks/znc.yml
+++ b/roles/ircbouncer/tasks/znc.yml
@@ -16,7 +16,7 @@
     - python3-dev
     - swig
   tags:
-    - deps
+    - dependencies
 
 - name: Download znc release
   get_url: url=http://znc.in/releases/archive/znc-{{ znc_version }}.tar.gz dest=/root/znc-{{ znc_version }}.tar.gz

--- a/roles/ircbouncer/tasks/znc.yml
+++ b/roles/ircbouncer/tasks/znc.yml
@@ -15,6 +15,8 @@
     - pkg-config
     - python3-dev
     - swig
+  tags:
+    - deps
 
 - name: Download znc release
   get_url: url=http://znc.in/releases/archive/znc-{{ znc_version }}.tar.gz dest=/root/znc-{{ znc_version }}.tar.gz

--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -2,7 +2,7 @@
   apt_repository: repo='deb http://http.debian.net/debian wheezy-backports main'
   when: ansible_distribution_release == 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Dovecot and related packages on Debian 7
   apt: pkg={{ item }} update_cache=yes state=latest default_release=wheezy-backports
@@ -15,7 +15,7 @@
     - dovecot-pop3d
   when: ansible_distribution_release == 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Dovecot and related packages on distributions other than Debian 7
   apt: pkg={{ item }} update_cache=yes state=installed
@@ -28,25 +28,25 @@
     - dovecot-pop3d
   when: ansible_distribution_release != 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Postgres 9.1 for Dovecot on older distributions
   apt: pkg=postgresql-9.1 state=present
   when: ansible_distribution_release != 'trusty' and ansible_distribution_release != 'jessie'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Postgres 9.3 for Dovecot on Ubuntu Trusty
   apt: pkg=postgresql-9.3 state=present
   when: ansible_distribution_release == 'trusty'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Postgres 9.4 for Dovecot on Debian Jessie
   apt: pkg=postgresql-9.4 state=present
   when: ansible_distribution_release == 'jessie'
   tags:
-    - deps
+    - dependencies
 
 - name: Create vmail group
   group: name=vmail state=present gid=5000

--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -1,6 +1,8 @@
 - name: Add wheezy-backports to get a reasonably current Dovecot on Debian 7
   apt_repository: repo='deb http://http.debian.net/debian wheezy-backports main'
   when: ansible_distribution_release == 'wheezy'
+  tags:
+    - deps
 
 - name: Install Dovecot and related packages on Debian 7
   apt: pkg={{ item }} update_cache=yes state=latest default_release=wheezy-backports
@@ -12,6 +14,8 @@
     - dovecot-pgsql
     - dovecot-pop3d
   when: ansible_distribution_release == 'wheezy'
+  tags:
+    - deps
 
 - name: Install Dovecot and related packages on distributions other than Debian 7
   apt: pkg={{ item }} update_cache=yes state=installed
@@ -23,18 +27,26 @@
     - dovecot-pgsql
     - dovecot-pop3d
   when: ansible_distribution_release != 'wheezy'
+  tags:
+    - deps
 
 - name: Install Postgres 9.1 for Dovecot on older distributions
   apt: pkg=postgresql-9.1 state=present
   when: ansible_distribution_release != 'trusty' and ansible_distribution_release != 'jessie'
+  tags:
+    - deps
 
 - name: Install Postgres 9.3 for Dovecot on Ubuntu Trusty
   apt: pkg=postgresql-9.3 state=present
   when: ansible_distribution_release == 'trusty'
+  tags:
+    - deps
 
 - name: Install Postgres 9.4 for Dovecot on Debian Jessie
   apt: pkg=postgresql-9.4 state=present
   when: ansible_distribution_release == 'jessie'
+  tags:
+    - deps
 
 - name: Create vmail group
   group: name=vmail state=present gid=5000

--- a/roles/mailserver/tasks/dspam.yml
+++ b/roles/mailserver/tasks/dspam.yml
@@ -7,7 +7,7 @@
     - postfix-pcre
   when: ansible_distribution_release == 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Install dspam and related packages on distributions other than wheezy
   apt: pkg={{ item }} state=installed
@@ -18,7 +18,7 @@
     - postfix-pcre
   when: ansible_distribution_release != 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Create dspam directory
   file: state=directory path=/decrypted/dspam group=dspam owner=dspam

--- a/roles/mailserver/tasks/dspam.yml
+++ b/roles/mailserver/tasks/dspam.yml
@@ -6,6 +6,8 @@
     - dspam
     - postfix-pcre
   when: ansible_distribution_release == 'wheezy'
+  tags:
+    - deps
 
 - name: Install dspam and related packages on distributions other than wheezy
   apt: pkg={{ item }} state=installed
@@ -15,6 +17,8 @@
     - dspam
     - postfix-pcre
   when: ansible_distribution_release != 'wheezy'
+  tags:
+    - deps
 
 - name: Create dspam directory
   file: state=directory path=/decrypted/dspam group=dspam owner=dspam

--- a/roles/mailserver/tasks/opendkim.yml
+++ b/roles/mailserver/tasks/opendkim.yml
@@ -6,6 +6,8 @@
   with_items:
     - opendkim
     - opendkim-tools
+  tags:
+    - deps
 
 - name: Create OpenDKIM config directory
   file: state=directory path=/etc/opendkim group=opendkim owner=opendkim

--- a/roles/mailserver/tasks/opendkim.yml
+++ b/roles/mailserver/tasks/opendkim.yml
@@ -7,7 +7,7 @@
     - opendkim
     - opendkim-tools
   tags:
-    - deps
+    - dependencies
 
 - name: Create OpenDKIM config directory
   file: state=directory path=/etc/opendkim group=opendkim owner=opendkim

--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -1,14 +1,20 @@
 - name: Install Postgres 9.1 on older distributions
   apt: pkg=postgresql-9.1 state=present
   when: ansible_distribution_release != 'trusty' and ansible_distribution_release != 'jessie'
+  tags:
+    - deps
 
 - name: Install Postgres 9.3 on Ubuntu Trusty
   apt: pkg=postgresql-9.3 state=present
   when: ansible_distribution_release == 'trusty'
+  tags:
+    - deps
 
 - name: Install Postgres 9.4 on Debian Jessie
   apt: pkg=postgresql-9.4 state=present
   when: ansible_distribution_release == 'jessie'
+  tags:
+    - deps
 
 - name: Install Postfix and related packages
   apt: pkg={{ item }} state=installed
@@ -20,6 +26,8 @@
     - postgrey
     - python-psycopg2
     - sasl2-bin
+  tags:
+    - deps
 
 - name: Set postgres password
   command: sudo -u {{ db_admin_username }} psql -d {{ db_admin_username }} -c "ALTER USER postgres with  password '{{ db_admin_password }}';"

--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -2,19 +2,19 @@
   apt: pkg=postgresql-9.1 state=present
   when: ansible_distribution_release != 'trusty' and ansible_distribution_release != 'jessie'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Postgres 9.3 on Ubuntu Trusty
   apt: pkg=postgresql-9.3 state=present
   when: ansible_distribution_release == 'trusty'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Postgres 9.4 on Debian Jessie
   apt: pkg=postgresql-9.4 state=present
   when: ansible_distribution_release == 'jessie'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Postfix and related packages
   apt: pkg={{ item }} state=installed
@@ -27,7 +27,7 @@
     - python-psycopg2
     - sasl2-bin
   tags:
-    - deps
+    - dependencies
 
 - name: Set postgres password
   command: sudo -u {{ db_admin_username }} psql -d {{ db_admin_username }} -c "ALTER USER postgres with  password '{{ db_admin_password }}';"

--- a/roles/mailserver/tasks/solr.yml
+++ b/roles/mailserver/tasks/solr.yml
@@ -4,6 +4,8 @@
     - dovecot-solr
     - solr-tomcat
   when: ansible_distribution_release == 'wheezy'
+  tags:
+    - deps
 
 - name: Install Solr and related packages on distributions other than wheezy
   apt: pkg={{ item }} state=installed
@@ -11,6 +13,8 @@
     - dovecot-solr
     - solr-tomcat
   when: ansible_distribution_release != 'wheezy'
+  tags:
+    - deps
 
 - name: Work around Debian bug and copy Solr schema file into place
   copy: src=solr-schema.xml dest=/etc/solr/conf/schema.xml group=root owner=root

--- a/roles/mailserver/tasks/solr.yml
+++ b/roles/mailserver/tasks/solr.yml
@@ -5,7 +5,7 @@
     - solr-tomcat
   when: ansible_distribution_release == 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Solr and related packages on distributions other than wheezy
   apt: pkg={{ item }} state=installed
@@ -14,7 +14,7 @@
     - solr-tomcat
   when: ansible_distribution_release != 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Work around Debian bug and copy Solr schema file into place
   copy: src=solr-schema.xml dest=/etc/solr/conf/schema.xml group=root owner=root

--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -6,7 +6,7 @@
     - php5-cli
     - php5-imap
   tags:
-    - deps
+    - dependencies
 
 - name: Download z-push release
   get_url:

--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -5,6 +5,8 @@
     - php5
     - php5-cli
     - php5-imap
+  tags:
+    - deps
 
 - name: Download z-push release
   get_url:

--- a/roles/monitoring/tasks/collectd.yml
+++ b/roles/monitoring/tasks/collectd.yml
@@ -2,7 +2,7 @@
   apt_repository: repo='deb http://http.debian.net/debian wheezy-backports main'
   when: ansible_distribution_release == 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Install collectd dependencies on wheezy from backports
   apt: pkg={{ item }} state=installed default_release=wheezy-backports
@@ -12,7 +12,7 @@
     - python-dev
   when: ansible_distribution_release == 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Install collectd dependencies on distributions other than wheezy
   apt: pkg={{ item }} state=installed
@@ -22,7 +22,7 @@
     - python-dev
   when: ansible_distribution_release != 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Download collectd
   get_url: url=http://collectd.org/files/collectd-{{collectd_version}}.tar.gz

--- a/roles/monitoring/tasks/collectd.yml
+++ b/roles/monitoring/tasks/collectd.yml
@@ -1,6 +1,8 @@
 - name: Add wheezy-backports to be compatible with Dovecot packages on Debian 7
   apt_repository: repo='deb http://http.debian.net/debian wheezy-backports main'
   when: ansible_distribution_release == 'wheezy'
+  tags:
+    - deps
 
 - name: Install collectd dependencies on wheezy from backports
   apt: pkg={{ item }} state=installed default_release=wheezy-backports
@@ -9,6 +11,8 @@
     - librrd2-dev
     - python-dev
   when: ansible_distribution_release == 'wheezy'
+  tags:
+    - deps
 
 - name: Install collectd dependencies on distributions other than wheezy
   apt: pkg={{ item }} state=installed
@@ -17,6 +21,8 @@
     - librrd2-dev
     - python-dev
   when: ansible_distribution_release != 'wheezy'
+  tags:
+    - deps
 
 - name: Download collectd
   get_url: url=http://collectd.org/files/collectd-{{collectd_version}}.tar.gz

--- a/roles/monitoring/tasks/logwatch.yml
+++ b/roles/monitoring/tasks/logwatch.yml
@@ -4,7 +4,7 @@
     - libdate-manip-perl
     - logwatch
   tags:
-    - deps
+    - dependencies
 
 - name: Configure logwatch
   template: src=etc_logwatch_conf_logwatch.conf.j2 dest=/etc/logwatch/conf/logwatch.conf

--- a/roles/monitoring/tasks/logwatch.yml
+++ b/roles/monitoring/tasks/logwatch.yml
@@ -3,6 +3,8 @@
   with_items:
     - libdate-manip-perl
     - logwatch
+  tags:
+    - deps
 
 - name: Configure logwatch
   template: src=etc_logwatch_conf_logwatch.conf.j2 dest=/etc/logwatch/conf/logwatch.conf

--- a/roles/monitoring/tasks/monit.yml
+++ b/roles/monitoring/tasks/monit.yml
@@ -7,6 +7,8 @@
 
 - name: Install monit
   apt: pkg=monit state=installed
+  tags:
+    - deps
 
 - name: Copy monit master config file into place
   copy: src=etc_monit_monitrc dest=/etc/monit/monitrc

--- a/roles/monitoring/tasks/monit.yml
+++ b/roles/monitoring/tasks/monit.yml
@@ -8,7 +8,7 @@
 - name: Install monit
   apt: pkg=monit state=installed
   tags:
-    - deps
+    - dependencies
 
 - name: Copy monit master config file into place
   copy: src=etc_monit_monitrc dest=/etc/monit/monitrc

--- a/roles/newebe/tasks/newebe.yml
+++ b/roles/newebe/tasks/newebe.yml
@@ -15,6 +15,8 @@
     - python-setuptools
     - python-lxml
     - supervisor
+  tags:
+    - deps
 
 - name: Install Newebe
   pip: name='git+https://github.com/gelnior/newebe.git#egg=newebe'

--- a/roles/newebe/tasks/newebe.yml
+++ b/roles/newebe/tasks/newebe.yml
@@ -16,7 +16,7 @@
     - python-lxml
     - supervisor
   tags:
-    - deps
+    - dependencies
 
 - name: Install Newebe
   pip: name='git+https://github.com/gelnior/newebe.git#egg=newebe'

--- a/roles/news/tasks/selfoss.yml
+++ b/roles/news/tasks/selfoss.yml
@@ -24,7 +24,7 @@
     - php5-pgsql
     - php5-gd
   tags:
-    - deps
+    - dependencies
 
 - name: Create database user for selfoss
   postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ selfoss_db_username }} password="{{ selfoss_db_password }}" state=present

--- a/roles/news/tasks/selfoss.yml
+++ b/roles/news/tasks/selfoss.yml
@@ -23,6 +23,8 @@
     - php5
     - php5-pgsql
     - php5-gd
+  tags:
+    - deps
 
 - name: Create database user for selfoss
   postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ selfoss_db_username }} password="{{ selfoss_db_password }}" state=present

--- a/roles/owncloud/tasks/owncloud.yml
+++ b/roles/owncloud/tasks/owncloud.yml
@@ -6,13 +6,13 @@
   apt: pkg=postgresql-9.1 state=present
   when: ansible_distribution_release != 'trusty'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Postgres 9.3 on Ubuntu Trusty
   apt: pkg=postgresql-9.3 state=present
   when: ansible_distribution_release == 'trusty'
   tags:
-    - deps
+    - dependencies
 
 - name: Install ownCloud dependencies
   apt: pkg={{ item }} state=present
@@ -21,7 +21,7 @@
     - php-apc
     - python-psycopg2
   tags:
-    - deps
+    - dependencies
 
 - name: Set postgres password
   command: sudo -u {{ db_admin_username }} psql -d {{ db_admin_username }} -c "ALTER USER postgres with  password '{{ db_admin_password }}';"
@@ -36,42 +36,42 @@
   apt_key: url=http://download.opensuse.org/repositories/isv:ownCloud:community/Debian_7.0/Release.key state=present
   when: ansible_distribution_release == 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Add ownCloud OpenSuSE repository for Debian 7
   apt_repository: repo='deb http://download.opensuse.org/repositories/isv:ownCloud:community/Debian_7.0/ /'
   when: ansible_distribution_release == 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Ensure repository key for ownCloud is in place for Ubuntu 14.04
   apt_key: url=http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_14.04/Release.key state=present
   when: ansible_distribution_release == 'trusty'
   tags:
-    - deps
+    - dependencies
 
 - name: Add ownCloud OpenSuSE repository for Ubuntu 14.04
   apt_repository: repo='deb http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_14.04/ /'
   when: ansible_distribution_release == 'trusty'
   tags:
-    - deps
+    - dependencies
 
 - name: Ensure repository key for ownCloud is in place for Ubuntu 12.04
   apt_key: url=http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_12.04/Release.key state=present
   when: ansible_distribution_release == 'precise'
   tags:
-    - deps
+    - dependencies
 
 - name: Add ownCloud OpenSuSE repository for Ubuntu 12.04
   apt_repository: repo='deb http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_12.04/ /'
   when: ansible_distribution_release == 'precise'
   tags:
-    - deps
+    - dependencies
 
 - name: Install ownCloud (possibly from OpenSuSE repository)
   apt: pkg=owncloud update_cache=yes
   tags:
-    - deps
+    - dependencies
 
 - name: Owncloud www directory
   file: state=directory path=/var/www/owncloud

--- a/roles/owncloud/tasks/owncloud.yml
+++ b/roles/owncloud/tasks/owncloud.yml
@@ -5,10 +5,14 @@
 - name: Install Postgres 9.1 on distributions other than Ubuntu Trusty
   apt: pkg=postgresql-9.1 state=present
   when: ansible_distribution_release != 'trusty'
+  tags:
+    - deps
 
 - name: Install Postgres 9.3 on Ubuntu Trusty
   apt: pkg=postgresql-9.3 state=present
   when: ansible_distribution_release == 'trusty'
+  tags:
+    - deps
 
 - name: Install ownCloud dependencies
   apt: pkg={{ item }} state=present
@@ -16,6 +20,8 @@
     - libapache2-mod-php5
     - php-apc
     - python-psycopg2
+  tags:
+    - deps
 
 - name: Set postgres password
   command: sudo -u {{ db_admin_username }} psql -d {{ db_admin_username }} -c "ALTER USER postgres with  password '{{ db_admin_password }}';"
@@ -29,29 +35,43 @@
 - name: Ensure repository key for ownCloud is in place for Debian 7
   apt_key: url=http://download.opensuse.org/repositories/isv:ownCloud:community/Debian_7.0/Release.key state=present
   when: ansible_distribution_release == 'wheezy'
+  tags:
+    - deps
 
 - name: Add ownCloud OpenSuSE repository for Debian 7
   apt_repository: repo='deb http://download.opensuse.org/repositories/isv:ownCloud:community/Debian_7.0/ /'
   when: ansible_distribution_release == 'wheezy'
+  tags:
+    - deps
 
 - name: Ensure repository key for ownCloud is in place for Ubuntu 14.04
   apt_key: url=http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_14.04/Release.key state=present
   when: ansible_distribution_release == 'trusty'
+  tags:
+    - deps
 
 - name: Add ownCloud OpenSuSE repository for Ubuntu 14.04
   apt_repository: repo='deb http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_14.04/ /'
   when: ansible_distribution_release == 'trusty'
+  tags:
+    - deps
 
 - name: Ensure repository key for ownCloud is in place for Ubuntu 12.04
   apt_key: url=http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_12.04/Release.key state=present
   when: ansible_distribution_release == 'precise'
+  tags:
+    - deps
 
 - name: Add ownCloud OpenSuSE repository for Ubuntu 12.04
   apt_repository: repo='deb http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_12.04/ /'
   when: ansible_distribution_release == 'precise'
+  tags:
+    - deps
 
 - name: Install ownCloud (possibly from OpenSuSE repository)
   apt: pkg=owncloud update_cache=yes
+  tags:
+    - deps
 
 - name: Owncloud www directory
   file: state=directory path=/var/www/owncloud

--- a/roles/readlater/tasks/wallabag.yml
+++ b/roles/readlater/tasks/wallabag.yml
@@ -20,6 +20,8 @@
     - php5-mcrypt
     - php5-pgsql
     - php5-tidy
+  tags:
+    - deps
 
 - name: Create database user for wallabag
   postgresql_user: login_host=localhost

--- a/roles/readlater/tasks/wallabag.yml
+++ b/roles/readlater/tasks/wallabag.yml
@@ -21,7 +21,7 @@
     - php5-pgsql
     - php5-tidy
   tags:
-    - deps
+    - dependencies
 
 - name: Create database user for wallabag
   postgresql_user: login_host=localhost

--- a/roles/tarsnap/tasks/tarsnap.yml
+++ b/roles/tarsnap/tasks/tarsnap.yml
@@ -4,7 +4,7 @@
   changed_when: "tarnsap_installed.stderr != ''"
   ignore_errors: yes
   tags:
-    - deps
+    - dependencies
 
 - name: Install dependencies for Tarsnap
   when: tarnsap_installed|failed
@@ -14,7 +14,7 @@
     - libssl-dev
     - zlib1g-dev
   tags:
-    - deps
+    - dependencies
 
 - name: Download the current tarsnap code signing key
   when: tarnsap_installed|failed

--- a/roles/tarsnap/tasks/tarsnap.yml
+++ b/roles/tarsnap/tasks/tarsnap.yml
@@ -3,6 +3,8 @@
   register: tarnsap_installed
   changed_when: "tarnsap_installed.stderr != ''"
   ignore_errors: yes
+  tags:
+    - deps
 
 - name: Install dependencies for Tarsnap
   when: tarnsap_installed|failed
@@ -11,6 +13,8 @@
     - e2fslibs-dev
     - libssl-dev
     - zlib1g-dev
+  tags:
+    - deps
 
 - name: Download the current tarsnap code signing key
   when: tarnsap_installed|failed

--- a/roles/vpn/tasks/openvpn.yml
+++ b/roles/vpn/tasks/openvpn.yml
@@ -8,6 +8,8 @@
     - dnsmasq
     - openvpn
     - udev
+  tags:
+    - deps
 
 - name: Generate RSA keys for the CA and Server
   command: openssl genrsa -out {{ item }}.key {{ openvpn_key_size }}

--- a/roles/vpn/tasks/openvpn.yml
+++ b/roles/vpn/tasks/openvpn.yml
@@ -9,7 +9,7 @@
     - openvpn
     - udev
   tags:
-    - deps
+    - dependencies
 
 - name: Generate RSA keys for the CA and Server
   command: openssl genrsa -out {{ item }}.key {{ openvpn_key_size }}

--- a/roles/webmail/tasks/roundcube.yml
+++ b/roles/webmail/tasks/roundcube.yml
@@ -2,12 +2,12 @@
   lineinfile: dest=/etc/apt/sources.list line="deb http://http.debian.net/debian wheezy-backports main"
   when: ansible_distribution_release == 'wheezy'
   tags:
-    - deps
+    - dependencies
   
 - name: Update apt cache for backports
   apt: update_cache=yes
   tags:
-    - deps
+    - dependencies
 
 - name: Install Roundcube from wheezy-backports
   apt: pkg={{ item }} state=latest default_release=wheezy-backports
@@ -17,7 +17,7 @@
   - roundcube-plugins
   when: ansible_distribution_release == 'wheezy'
   tags:
-    - deps
+    - dependencies
 
 - name: Install Roundcube on Ubuntu 14.04 LTS
   apt: pkg={{ item }} state=latest
@@ -27,7 +27,7 @@
   - roundcube-plugins
   when: ansible_distribution_release == 'trusty'
   tags:
-    - deps
+    - dependencies
 
 - name: Configure Roundcube database
   template: src={{ item.src }} dest={{ item.dest }} group={{ item.group }} mode={{ item.mode }} owner=root force=yes

--- a/roles/webmail/tasks/roundcube.yml
+++ b/roles/webmail/tasks/roundcube.yml
@@ -1,9 +1,13 @@
 - name: Add backports for Roundcube on Debian
   lineinfile: dest=/etc/apt/sources.list line="deb http://http.debian.net/debian wheezy-backports main"
   when: ansible_distribution_release == 'wheezy'
+  tags:
+    - deps
   
 - name: Update apt cache for backports
   apt: update_cache=yes
+  tags:
+    - deps
 
 - name: Install Roundcube from wheezy-backports
   apt: pkg={{ item }} state=latest default_release=wheezy-backports
@@ -12,6 +16,8 @@
   - roundcube-pgsql
   - roundcube-plugins
   when: ansible_distribution_release == 'wheezy'
+  tags:
+    - deps
 
 - name: Install Roundcube on Ubuntu 14.04 LTS
   apt: pkg={{ item }} state=latest
@@ -20,6 +26,8 @@
   - roundcube-pgsql
   - roundcube-plugins
   when: ansible_distribution_release == 'trusty'
+  tags:
+    - deps
 
 - name: Configure Roundcube database
   template: src={{ item.src }} dest={{ item.dest }} group={{ item.group }} mode={{ item.mode }} owner=root force=yes

--- a/roles/xmpp/tasks/prosody.yml
+++ b/roles/xmpp/tasks/prosody.yml
@@ -1,31 +1,31 @@
 - name: Ensure repository key for Prosody is in place
   apt_key: url=https://prosody.im/files/prosody-debian-packages.key state=present
   tags:
-    - deps
+    - dependencies
 
 # Prosody supplies repo for sid, squeeze, wheezy, jessie, trusty, saucy, raring, quantal, precise and lucid
 - name: Add Prosody Debian/Ubuntu repository
   apt_repository: repo="deb http://packages.prosody.im/debian {{ ansible_distribution_release }} main"
   tags:
-    - deps
+    - dependencies
 
 - name: Install Prosody from official repository
   apt: pkg=prosody update_cache=yes
   tags:
-    - deps
+    - dependencies
 
 - name: Install lua-sec-prosody on Debian Wheezy and Ubuntu Precise
   apt: pkg=lua-sec-prosody update_cache=yes
   when: ansible_distribution_release == 'wheezy' or ansible_distribution_release == 'precise'
   tags:
-    - deps
+    - dependencies
 
 
 - name: Install lua-sec 0.5+
   apt: pkg=lua-sec update_cache=yes
   when: ansible_distribution_release == 'trusty' or ansible_distribution_release == 'jessie'
   tags:
-    - deps
+    - dependencies
 
 - name: Add prosody user to ssl-cert group
   user: name=prosody groups=ssl-cert append=yes

--- a/roles/xmpp/tasks/prosody.yml
+++ b/roles/xmpp/tasks/prosody.yml
@@ -1,20 +1,31 @@
 - name: Ensure repository key for Prosody is in place
   apt_key: url=https://prosody.im/files/prosody-debian-packages.key state=present
+  tags:
+    - deps
 
 # Prosody supplies repo for sid, squeeze, wheezy, jessie, trusty, saucy, raring, quantal, precise and lucid
 - name: Add Prosody Debian/Ubuntu repository
   apt_repository: repo="deb http://packages.prosody.im/debian {{ ansible_distribution_release }} main"
+  tags:
+    - deps
 
 - name: Install Prosody from official repository
   apt: pkg=prosody update_cache=yes
+  tags:
+    - deps
 
 - name: Install lua-sec-prosody on Debian Wheezy and Ubuntu Precise
   apt: pkg=lua-sec-prosody update_cache=yes
   when: ansible_distribution_release == 'wheezy' or ansible_distribution_release == 'precise'
+  tags:
+    - deps
+
 
 - name: Install lua-sec 0.5+
   apt: pkg=lua-sec update_cache=yes
   when: ansible_distribution_release == 'trusty' or ansible_distribution_release == 'jessie'
+  tags:
+    - deps
 
 - name: Add prosody user to ssl-cert group
   user: name=prosody groups=ssl-cert append=yes


### PR DESCRIPTION
Hello,

I'm trying to create a ready-to-use cloud image on Scaleway.
My commit adds a tag 'deps' on all aptitude tasks, so I can easily run the non-dynamic tasks by calling something like: `ansible-playbook --tags=deps site.yml`.
Then, the user can edit `vars` and continue the installation with a lots of time saved.

I don't break the original tagging feature and if you call `ansible-playbook --tags=vpn` it will call all vpn tasks (deps and non-deps ones).