### PR TITLE
Add missing OpenDMARC dependencies

### DIFF
--- a/roles/mailserver/tasks/dmarc.yml
+++ b/roles/mailserver/tasks/dmarc.yml
@@ -1,5 +1,11 @@
-- name: Install OpenDMARC milter
-  apt: pkg=opendmarc state=installed update_cache=yes
+- name: Install OpenDMARC milter and related packages
+  apt: pkg={{item}} state=installed
+  with_items:
+    - mysql-server
+    - opendmarc
+    - python-mysqldb
+  tags:
+    - dependencies
 
 - name: Copy OpenDMARC configuration file into place
   template: src=etc_opendmarc.conf.j2 dest=/etc/opendmarc.conf owner=root group=root
@@ -35,4 +41,3 @@
 
 - name: Activate OpenDMARC report cronjob
   cron: name="OpenDMARC report" hour="2" minute="0" job="/bin/bash /etc/opendmarc/report.sh >> /var/log/opendmarc_report.log"
-

--- a/vars/testing.yml
+++ b/vars/testing.yml
@@ -25,6 +25,7 @@ irc_timezone: "America/New_York" #Example: "America/New_York"
 
 # mailserver
 mail_db_password: testPassword
+mail_db_opendmarc_password: testPassword
 mail_virtual_domains:
   - name: "{{ domain }}"
     pk_id: 1


### PR DESCRIPTION
When setting up a sovereign dev VM for the first time, I ran into a problem with some missing dependencies and a missing var for the OpenDMARC setup.

These changes allowed the VM to finish provisioning successfully, but I have not yet gotten as far as, you know, verifying that OpenDMARC is working as expected.  Any advice on how best to do that would be appreciated!