### PR TITLE
Added whois for fail2ban report

### DIFF
--- a/roles/common/tasks/security.yml
+++ b/roles/common/tasks/security.yml
@@ -2,6 +2,7 @@
   apt: pkg={{ item }} state=installed
   with_items:
     - fail2ban
+    - whois
     - lynis
     - rkhunter
   tags:


### PR DESCRIPTION
Report will print: "missing whois program"