### PR TITLE
Couple issues with OpenDMARC on Debian 7:

### DIFF
--- a/roles/mailserver/tasks/dmarc.yml
+++ b/roles/mailserver/tasks/dmarc.yml
@@ -1,5 +1,8 @@
-- name: Install OpenDMARC milter
-  apt: pkg=opendmarc state=installed update_cache=yes
+- name: Install OpenDMARC milter and related packages
+  apt: pkg={{ item }} state=installed update_cache=yes
+  with_items:
+      - python-mysqldb
+      - opendmarc
 
 - name: Copy OpenDMARC configuration file into place
   template: src=etc_opendmarc.conf.j2 dest=/etc/opendmarc.conf owner=root group=root

--- a/vars/user.yml
+++ b/vars/user.yml
@@ -88,5 +88,3 @@ selfoss_password_hash: "TODO"
 wallabag_salt: TODO
 wallabag_db_password: TODO
 
-mail_db_opendmarc_username: opendmarc
-mail_db_opendmarc_password: TODO

--- a/vars/user.yml
+++ b/vars/user.yml
@@ -87,4 +87,3 @@ selfoss_password_hash: "TODO"
 # wallabag
 wallabag_salt: TODO
 wallabag_db_password: TODO
-

--- a/vars/user.yml
+++ b/vars/user.yml
@@ -87,3 +87,6 @@ selfoss_password_hash: "TODO"
 # wallabag
 wallabag_salt: TODO
 wallabag_db_password: TODO
+
+mail_db_opendmarc_username: opendmarc
+mail_db_opendmarc_password: TODO


### PR DESCRIPTION
Yesterday trying to upgrade Sovereign on my debian 7 VPS along few issues, I got problem install opendmarc. I fixed it with changes in this PR.

 * fix mail_db_opendmarc_username/mail_db_opendmarc_password variable  not found.
 * python-mysqldb package is required. Add it to opendmarc task.