### PR TITLE
Use lmtp instead of lda for delivery.

### DIFF
--- a/roles/mailserver/files/etc_postfix_master.cf
+++ b/roles/mailserver/files/etc_postfix_master.cf
@@ -117,4 +117,4 @@ mailman   unix  -       n       n       -       -       pipe
 dspam     unix  -       n       n       -       10      pipe
   flags=Ru user=dspam argv=/usr/bin/dspam --deliver=innocent,spam --user ${user}@${domain} -i -f $sender -- $recipient
 dovecot   unix  -       n       n       -       -       pipe
-  flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/dovecot-lda -f ${sender} -d ${user}@${nexthop}
+  flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/lmtp -f ${sender} -d ${user}@${nexthop}

--- a/roles/mailserver/templates/etc_postfix_main.cf.j2
+++ b/roles/mailserver/templates/etc_postfix_main.cf.j2
@@ -91,7 +91,9 @@ recipient_delimiter = +
 inet_interfaces = all
 
 # dovecot db
-virtual_transport = dovecot
+virtual_transport = lmtp:unix:private/dovecot-lmtp
+mailbox_transport = lmtp:unix:private/dovecot-lmtp
+
 dovecot_destination_recipient_limit = 1
 virtual_mailbox_domains = pgsql:/etc/postfix/pgsql-virtual-mailbox-domains.cf
 virtual_mailbox_maps = pgsql:/etc/postfix/pgsql-virtual-mailbox-maps.cf


### PR DESCRIPTION
This fixes #375.

It turns out that everything was already set up and the only work was to tell postfix to use lmtp instead of lda. Tested on Debian 7.

Please review.