### PR TITLE
Change shell to copy content

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -42,7 +42,7 @@
     - dependencies
 
 - name: Set timezone to UTC
-  action: shell echo Etc/UTC > /etc/timezone
+  copy: content='Etc/UTC' dest=/etc/timezone
 
 - name: Set localtime to UTC
   file: src=/usr/share/zoneinfo/Etc/UTC dest=/etc/localtime


### PR DESCRIPTION
Hi, Just removing `shell` to `copy` with `content` option that IMHO is cleaner.
Cheers