### PR TITLE
Z-push apache config: Jessie also uses conf-available/conf-enabled

### DIFF
--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -41,19 +41,12 @@
 - name: Copy z-push's config.php into place
   template: src=usr_share_z-push_config.php.j2 dest=/usr/share/z-push/config.php
 
-- name: Configure z-push apache alias and php settings
-  copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf.d/z-push.conf
-  notify: restart apache
-  when: ansible_distribution_release != 'trusty'
-
-- name: Create z-push apache alias and php configuration file for Ubuntu Trusty
+- name: Create z-push Apache alias and PHP configuration file
   copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf-available/z-push.conf
-  when: ansible_distribution_release == 'trusty'
 
-- name: Enable z-push Apache alias and PHP configuration file for Ubuntu Trusty
+- name: Enable z-push Apache alias and PHP configuration file
   command: a2enconf z-push creates=/etc/apache2/conf-enabled/z-push.conf
   notify: restart apache
-  when: ansible_distribution_release == 'trusty'
 
 - name: Configure z-push logrotate
   copy: src=etc_logrotate_z-push dest=/etc/logrotate.d/z-push owner=root group=root mode=0644

--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -41,12 +41,19 @@
 - name: Copy z-push's config.php into place
   template: src=usr_share_z-push_config.php.j2 dest=/usr/share/z-push/config.php
 
-- name: Create z-push Apache alias and PHP configuration file
-  copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf-available/z-push.conf
+- name: Configure z-push apache alias and php settings
+  copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf.d/z-push.conf
+  notify: restart apache
+  when: ansible_distribution_release != 'trusty'
 
-- name: Enable z-push Apache alias and PHP configuration file
+- name: Create z-push apache alias and php configuration file for Ubuntu Trusty
+  copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf-available/z-push.conf
+  when: ansible_distribution_release == 'trusty'
+
+- name: Enable z-push Apache alias and PHP configuration file for Ubuntu Trusty
   command: a2enconf z-push creates=/etc/apache2/conf-enabled/z-push.conf
   notify: restart apache
+  when: ansible_distribution_release == 'trusty'
 
 - name: Configure z-push logrotate
   copy: src=etc_logrotate_z-push dest=/etc/logrotate.d/z-push owner=root group=root mode=0644

--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -44,16 +44,19 @@
 - name: Configure z-push apache alias and php settings
   copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf.d/z-push.conf
   notify: restart apache
-  when: ansible_distribution_release != 'trusty'
+  when: ansible_distribution_release != 'trusty' or ansible_distribution_release != 'jessie'
 
-- name: Create z-push apache alias and php configuration file for Ubuntu Trusty
+
+- name: Create z-push apache alias and php configuration file for Ubuntu Trusty / jessie
   copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf-available/z-push.conf
-  when: ansible_distribution_release == 'trusty'
+  when: ansible_distribution_release == 'trusty' or ansible_distribution_release == 'jessie'
 
-- name: Enable z-push Apache alias and PHP configuration file for Ubuntu Trusty
+
+- name: Enable z-push Apache alias and PHP configuration file for Ubuntu Trusty / jessie
   command: a2enconf z-push creates=/etc/apache2/conf-enabled/z-push.conf
   notify: restart apache
-  when: ansible_distribution_release == 'trusty'
+  when: ansible_distribution_release == 'trusty' or ansible_distribution_release == 'jessie'
+
 
 - name: Configure z-push logrotate
   copy: src=etc_logrotate_z-push dest=/etc/logrotate.d/z-push owner=root group=root mode=0644


### PR DESCRIPTION
Debian Jessie now also uses the a2enconf and conf-available/conf-enabled system, so there is no need to have separate entries for jessie and trusty any longer.

Tested only on jessie but nothing changes for trusty.