### PR TITLE
Improve openvpn security

### DIFF
--- a/roles/vpn/templates/etc_openvpn_server.conf.j2
+++ b/roles/vpn/templates/etc_openvpn_server.conf.j2
@@ -306,7 +306,11 @@ verb {{ openvpn_verb }}
 # category will be output to the log.
 ;mute 20
 
-# Mask your settings with mtu
+# Openvpn changes length of network packages
+# in the certain chunk that depends on
+# chipher and hash-sum algorithms.
+# So, mask your settings by using a lower mtu ;)
+# You can check parameters at this site:
 # witch.valdikss.org.ru
 tun-mtu {{ openvpn_mtu }}
 

--- a/roles/vpn/templates/etc_openvpn_server.conf.j2
+++ b/roles/vpn/templates/etc_openvpn_server.conf.j2
@@ -188,9 +188,9 @@ ifconfig-pool-persist ipp.txt
 # or bridge the TUN/TAP interface to the internet
 # in order for this to work properly).
 ;push "redirect-gateway def1 bypass-dhcp"
+;push "dhcp-option DNS 8.8.8.8"
 push "redirect-gateway def1"
 push "dhcp-option DNS 10.8.0.1"
-push "dhcp-option DNS 8.8.8.8"
 
 # Certain Windows-specific network settings
 # can be pushed to clients, such as DNS

--- a/roles/vpn/templates/etc_openvpn_server.conf.j2
+++ b/roles/vpn/templates/etc_openvpn_server.conf.j2
@@ -190,6 +190,7 @@ ifconfig-pool-persist ipp.txt
 ;push "redirect-gateway def1 bypass-dhcp"
 push "redirect-gateway def1"
 push "dhcp-option DNS 10.8.0.1"
+push "dhcp-option DNS 8.8.8.8"
 
 # Certain Windows-specific network settings
 # can be pushed to clients, such as DNS
@@ -298,9 +299,18 @@ status openvpn-status.log
 # 4 is reasonable for general usage
 # 5 and 6 can help to debug connection problems
 # 9 is extremely verbose
-verb 3
+verb {{ openvpn_verb }}
 
 # Silence repeating messages.  At most 20
 # sequential messages of the same message
 # category will be output to the log.
 ;mute 20
+
+# Mask your settings with mtu
+# witch.valdikss.org.ru
+tun-mtu {{ openvpn_mtu }}
+
+# Set TLS settings
+# Only for openvpn 2.3.3 and >2.3.4
+{{ openvpn_tls_version_min }}
+{{ openvpn_tls_cipher }}

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -81,6 +81,8 @@ owncloud_db_database: owncloud
 tarsnap_version: 1.0.35
 
 # vpn
+# Notes about security: https://blog.g3rt.nl/openvpn-security-tips.html
+# Check privacy: http://witch.valdikss.org.ru/
 # openvpn_key_country: (required)
 # openvpn_key_province: (required)
 # openvpn_key_city: (required)
@@ -89,8 +91,8 @@ tarsnap_version: 1.0.35
 openvpn_days_valid: "1825"
 openssl_request_subject: "/C={{ openvpn_key_country }}/ST={{ openvpn_key_province }}/L={{ openvpn_key_city }}/O={{ openvpn_key_org }}/OU={{ openvpn_key_ou }}"
 openvpn_key_size: "2048"
-openvpn_cipher: "BF-CBC"
-openvpn_auth_digest: "SHA1"
+openvpn_cipher: "AES-256-CBC"
+openvpn_auth_digest: "SHA512"
 openvpn_path: "/etc/openvpn"
 openvpn_ca: "{{ openvpn_path }}/ca"
 openvpn_dhparam: "{{ openvpn_path }}/dh{{ openvpn_key_size }}.pem"
@@ -98,6 +100,11 @@ openvpn_hmac_firewall: "{{ openvpn_path }}/ta.key"
 openvpn_server: "{{ domain }}"
 openvpn_port: "1194"
 openvpn_protocol: "udp"
+openvpn_mtu: "1300"
+openvpn_verb: "3" # "0" for anonymity
+# uncomment for openvpn 2.3.3 and >2.3.4
+openvpn_tls_version_min: "" # "tls-version-min 1.2"
+openvpn_tls_cipher: "" # "tls-cipher TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256:TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256:TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256"
 # openvpn_clients: (required)
 
 # webmail


### PR DESCRIPTION
Variables:
- change `chiper` to "AES-256-CBC"
- change `auth` to "SHA512"
- add `verb` level
- add `tun-mtu` for disguising
- add `tls-version-min` and `tls-cipher`

Config:
- add google dns
- add new variables

Src:
- blog.g3rt.nl/openvpn-security-tips.html
- community.openvpn.net/openvpn/ticket/401
- witch.valdikss.org.ru