### PR TITLE
sl: properly install changed certificate and restart apache on changes

### DIFF
--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -1,14 +1,17 @@
 - name: Copy SSL private key into place
   copy: src=wildcard_private.key dest=/etc/ssl/private/wildcard_private.key group=ssl-cert owner=root mode=640
   register: private_key
+  notify: restart apache
 
 - name: Copy SSL public certificate into place
   copy: src=wildcard_public_cert.crt dest=/etc/ssl/certs/wildcard_public_cert.crt group=root owner=root mode=644
   register: certificate
+  notify: restart apache
 
 - name: Copy CA combined certificate into place
   copy: src=wildcard_ca.pem dest=/etc/ssl/certs/wildcard_ca.pem group=root owner=root mode=644
   register: ca_certificate
+  notify: restart apache
 
 - name: Create a combined version of the public cert with intermediate and root CAs
   shell: cat /etc/ssl/certs/wildcard_public_cert.crt /etc/ssl/certs/wildcard_ca.pem >
@@ -17,15 +20,18 @@
 
 - name: Set permissions on combined public cert
   file: name=/etc/ssl/certs/wildcard_combined.pem mode=644
+  notify: restart apache
 
 - name: Enable Apache SSL module
   command: a2enmod ssl creates=/etc/apache2/mods-enabled/ssl.load
+  notify: restart apache
 
 - name: Enable NameVirtualHost for HTTPS
   lineinfile:
     dest=/etc/apache2/ports.conf regexp='^    NameVirtualHost \*:443'
     insertafter='^<IfModule mod_ssl.c>'
     line='    NameVirtualHost *:443'
+  notify: restart apache
 
 - name: Add common Apache SSL config
   template:
@@ -33,3 +39,4 @@
     dest=/etc/apache2/ssl.conf
     owner=root
     group=root
+  notify: restart apache

--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -1,15 +1,19 @@
 - name: Copy SSL private key into place
   copy: src=wildcard_private.key dest=/etc/ssl/private/wildcard_private.key group=ssl-cert owner=root mode=640
+  register: private_key
 
 - name: Copy SSL public certificate into place
   copy: src=wildcard_public_cert.crt dest=/etc/ssl/certs/wildcard_public_cert.crt group=root owner=root mode=644
+  register: certificate
 
 - name: Copy CA combined certificate into place
   copy: src=wildcard_ca.pem dest=/etc/ssl/certs/wildcard_ca.pem group=root owner=root mode=644
+  register: ca_certificate
 
 - name: Create a combined version of the public cert with intermediate and root CAs
   shell: cat /etc/ssl/certs/wildcard_public_cert.crt /etc/ssl/certs/wildcard_ca.pem >
-    /etc/ssl/certs/wildcard_combined.pem creates=/etc/ssl/certs/wildcard_combined.pem
+    /etc/ssl/certs/wildcard_combined.pem
+  when: private_key.changed or certificate.changed or ca_certificate.changed
 
 - name: Set permissions on combined public cert
   file: name=/etc/ssl/certs/wildcard_combined.pem mode=644
@@ -18,7 +22,10 @@
   command: a2enmod ssl creates=/etc/apache2/mods-enabled/ssl.load
 
 - name: Enable NameVirtualHost for HTTPS
-  lineinfile: dest=/etc/apache2/ports.conf regexp='^    NameVirtualHost \*:443' insertafter='^<IfModule mod_ssl.c>' line='    NameVirtualHost *:443'
+  lineinfile:
+    dest=/etc/apache2/ports.conf regexp='^    NameVirtualHost \*:443'
+    insertafter='^<IfModule mod_ssl.c>'
+    line='    NameVirtualHost *:443'
 
 - name: Add common Apache SSL config
   template:


### PR DESCRIPTION
I was stupidly using the certificates provided in the repo, and then I generated some self-signed ones but found out that they were not properly installed. The `creates=/etc/ssl/certs/wildcard_combined.pem` was making the task to skip which it shouldn't. So I fixed that, and also thought it should restart apache by itself.
