### PR TITLE
Optionally add HSTS header

### DIFF
--- a/roles/common/templates/etc_apache2_ssl.conf.j2
+++ b/roles/common/templates/etc_apache2_ssl.conf.j2
@@ -11,4 +11,7 @@ SSLCipherSuite ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-R
 SSLCertificateFile      /etc/ssl/certs/wildcard_public_cert.crt
 SSLCertificateKeyFile   /etc/ssl/private/wildcard_private.key
 SSLCACertificateFile    /etc/ssl/certs/wildcard_ca.pem
-Header add Strict-Transport-Security "max-age=15768000; includeSubdomains"
+
+{% if http_add_hsts_header %}
+    Header add Strict-Transport-Security "max-age=15768000; includeSubdomains"
+{% endif %}

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -11,6 +11,7 @@ common_timezone: 'Etc/UTC'
 admin_email: "{{ main_user_name }}@{{ domain }}"
 main_user_shell: "/bin/bash"
 # encfs_password: (required)
+http_add_hsts_header: true
 friendly_networks:
   - ""
 


### PR DESCRIPTION
For self signed certificates, when the server adds the HSTS header, firefox will refuse to connect to it, and won't even let you add to add an exception. So I added a variable that by default adds the header.

I am not sure how well we can communicate the existence of this option with the users. Should I add it in the README?