### PR TITLE
Fix selfoss permissions

### DIFF
--- a/roles/news/tasks/selfoss.yml
+++ b/roles/news/tasks/selfoss.yml
@@ -9,7 +9,11 @@
 
 # only data/cache, data/favicons, data/logs, data/thumbnails, data/sqlite public/ should be writeable by httpd
 - name: Set selfoss permission
-  action: file path=/var/www/selfoss/{{ item }} mode=0775
+  action:
+    file path=/var/www/selfoss/{{ item }}
+    owner=www-data
+    group=www-data
+    recurse=yes
   with_items:
     - data/cache
     - data/favicons


### PR DESCRIPTION
I got this mail from cron/logrotate:

```
/etc/cron.daily/logrotate:
error: skipping "/var/www/selfoss/data/logs/default.log" because parent directory has insecure
permissions (It's world writable or writable by group which is not "root")
Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
run-parts: /etc/cron.daily/logrotate exited with return code 1
```

i think the permissions I set in this PR are more appropriate.