### PR TITLE
Remove reference to Google's DNS servers

### DIFF
--- a/roles/vpn/templates/etc_openvpn_server.conf.j2
+++ b/roles/vpn/templates/etc_openvpn_server.conf.j2
@@ -187,8 +187,6 @@ ifconfig-pool-persist ipp.txt
 # (The OpenVPN server machine may need to NAT
 # or bridge the TUN/TAP interface to the internet
 # in order for this to work properly).
-;push "redirect-gateway def1 bypass-dhcp"
-;push "dhcp-option DNS 8.8.8.8"
 push "redirect-gateway def1"
 push "dhcp-option DNS 10.8.0.1"
 


### PR DESCRIPTION
Per discussion on #429 (after the merge). This project is about encouraging users to run services themselves and not rely on for-profit corporations such as Google.