### PR TITLE
update openvpn server config

### DIFF
--- a/roles/vpn/templates/etc_openvpn_server.conf.j2
+++ b/roles/vpn/templates/etc_openvpn_server.conf.j2
@@ -315,3 +315,11 @@ tun-mtu {{ openvpn_mtu }}
 # Only for openvpn 2.3.3 and >2.3.4
 {{ openvpn_tls_version_min }}
 {{ openvpn_tls_cipher }}
+
+# Change default network buffer size
+# Should increase tcp tunnel speed for openvpn < 2.3.9
+# https://community.openvpn.net/openvpn/ticket/461
+sndbuf 0
+rcvbuf 0
+push "sndbuf 393216"
+push "rcvbuf 393216"


### PR DESCRIPTION
Change default network buffer size
Should increase tcp tunnel speed for openvpn < 2.3.9
https://community.openvpn.net/openvpn/ticket/461