### PR TITLE
Set opendmarc password in testing.

### DIFF
--- a/vars/testing.yml
+++ b/vars/testing.yml
@@ -26,6 +26,7 @@ irc_timezone: "America/New_York" #Example: "America/New_York"
 
 # mailserver
 mail_db_password: testPassword
+mail_db_opendmarc_password: testPassword
 mail_virtual_domains:
   - name: "{{ domain }}"
     pk_id: 1


### PR DESCRIPTION
This should fix #479, though even with this fix I can't get `vagrant up` to run on master (now it fails with `psql: FATAL:  database "roundcube" does not exist` on the "set roundcube password" step).