### PR TITLE
Fix version of tomcat

### DIFF
--- a/roles/mailserver/files/etc_tomcat7_server.xml
+++ b/roles/mailserver/files/etc_tomcat7_server.xml
@@ -69,7 +69,7 @@
          APR (HTTP/AJP) Connector: /docs/apr.html
          Define a non-SSL HTTP/1.1 Connector on port 8080
     -->
-    <Connector port="8080" protocol="HTTP/1.1"
+    <Connector address="127.0.0.1" port="8080" protocol="HTTP/1.1"
                connectionTimeout="20000"
                URIEncoding="UTF-8"
                redirectPort="8443" />

--- a/roles/mailserver/files/etc_tomcat7_server.xml
+++ b/roles/mailserver/files/etc_tomcat7_server.xml
@@ -20,7 +20,9 @@
      Documentation at /docs/config/server.html
  -->
 <Server port="8005" shutdown="SHUTDOWN">
-
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
   <!--APR library loader. Documentation at /docs/apr.html -->
   <!--
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
@@ -29,9 +31,8 @@
   <Listener className="org.apache.catalina.core.JasperListener" />
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
-  <!-- JMX Support for the Tomcat server. Documentation at /docs/non-existent.html -->
-  <Listener className="org.apache.catalina.mbeans.ServerLifecycleListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
 
   <!-- Global JNDI resources
        Documentation at /docs/jndi-resources-howto.html
@@ -68,7 +69,7 @@
          APR (HTTP/AJP) Connector: /docs/apr.html
          Define a non-SSL HTTP/1.1 Connector on port 8080
     -->
-    <Connector address="127.0.0.1" port="8080" protocol="HTTP/1.1"
+    <Connector port="8080" protocol="HTTP/1.1"
                connectionTimeout="20000"
                URIEncoding="UTF-8"
                redirectPort="8443" />
@@ -80,12 +81,13 @@
                redirectPort="8443" />
     -->
     <!-- Define a SSL HTTP/1.1 Connector on port 8443
-         This connector uses the JSSE configuration, when using APR, the
-         connector should be using the OpenSSL style configuration
-         described in the APR documentation -->
+         This connector uses the BIO implementation that requires the JSSE
+         style configuration. When using the APR/native implementation, the
+         OpenSSL style configuration is required as described in the APR/native
+         documentation -->
     <!--
-    <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"
-               maxThreads="150" scheme="https" secure="true"
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11Protocol"
+               maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
                clientAuth="false" sslProtocol="TLS" />
     -->
 
@@ -113,26 +115,19 @@
       <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
       -->
 
-      <!-- The request dumper valve dumps useful debugging information about
-           the request and response data received and sent by Tomcat.
-           Documentation at: /docs/config/valve.html -->
-      <!--
-      <Valve className="org.apache.catalina.valves.RequestDumperValve"/>
-      -->
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
 
-      <!-- This Realm uses the UserDatabase configured in the global JNDI
-           resources under the key "UserDatabase".  Any edits
-           that are performed against this UserDatabase are immediately
-           available for use by the Realm.  -->
-      <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
-             resourceName="UserDatabase"/>
-
-      <!-- Define the default virtual host
-           Note: XML Schema validation will not work with Xerces 2.2.
-       -->
       <Host name="localhost"  appBase="webapps"
-            unpackWARs="true" autoDeploy="true"
-            xmlValidation="false" xmlNamespaceAware="false">
+            unpackWARs="true" autoDeploy="true">
 
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->
@@ -141,11 +136,11 @@
         -->
 
         <!-- Access log processes all example.
-             Documentation at: /docs/config/valve.html -->
-        <!--
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-               prefix="localhost_access_log." suffix=".txt" pattern="common" resolveHosts="false"/>
-        -->
+               prefix="localhost_access_log." suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 
       </Host>
     </Engine>

--- a/roles/mailserver/handlers/main.yml
+++ b/roles/mailserver/handlers/main.yml
@@ -8,7 +8,7 @@
   service: name=opendkim state=restarted
 
 - name: restart solr
-  service: name=tomcat8 state=restarted
+  service: name=tomcat7 state=restarted
 
 - name: import sql postfix
   action: shell PGPASSWORD='{{ mail_db_password }}' psql -h localhost -d {{ mail_db_database }} -U {{ mail_db_username }} -f /etc/postfix/import.sql --set ON_ERROR_STOP=1

--- a/roles/mailserver/tasks/solr.yml
+++ b/roles/mailserver/tasks/solr.yml
@@ -2,7 +2,6 @@
   apt: pkg={{ item }} state=installed
   with_items:
     - dovecot-solr
-    - tomcat8
     - solr-tomcat
   tags:
     - dependencies
@@ -11,7 +10,7 @@
   copy: src=solr-schema.xml dest=/etc/solr/conf/schema.xml group=root owner=root
 
 - name: Copy tweaked Tomcat config file into place
-  copy: src=etc_tomcat8_server.xml dest=/etc/tomcat8/server.xml group=tomcat8 owner=root
+  copy: src=etc_tomcat7_server.xml dest=/etc/tomcat7/server.xml group=tomcat7 owner=root
   notify: restart solr
 
 - name: Copy tweaked Solr config file into place
@@ -19,5 +18,5 @@
   notify: restart solr
 
 - name: Create Solr index directory
-  file: state=directory path=/decrypted/solr group=tomcat8 owner=tomcat8
+  file: state=directory path=/decrypted/solr group=tomcat7 owner=tomcat7
   notify: restart solr

--- a/roles/monitoring/files/etc_monit_conf.d_tomcat
+++ b/roles/monitoring/files/etc_monit_conf.d_tomcat
@@ -1,6 +1,6 @@
-check process tomcat with pidfile "/var/run/tomcat8.pid"
+check process tomcat with pidfile "/var/run/tomcat7.pid"
   group mail
-  start program = "systemctl start tomcat8"
-  stop program = "systemctl stop tomcat8"
+  start program = "systemctl start tomcat7"
+  stop program = "systemctl stop tomcat7"
   if failed port 8080 then alert
   if failed port 8080 for 5 cycles then restart


### PR DESCRIPTION
Both jessie and wily use the standard solr package, which expects tomcat7.  This PR switches from tomcat8 to tomcat7.  This prevents tomcat7 and tomcat8 from both being installed and thus fighting over port 8080 and generating monitoring alerts.