### PR TITLE
Clean up Apache SSL configuration

### DIFF
--- a/roles/blog/templates/etc_apache2_sites-available_blog.j2
+++ b/roles/blog/templates/etc_apache2_sites-available_blog.j2
@@ -9,8 +9,7 @@
 <VirtualHost *:443>
     ServerName {{ domain }}
     ServerAlias www.{{ domain }}
-
-    Include /etc/apache2/ssl.conf
+    SSLEngine On
 
     DocumentRoot            "/var/www/{{ domain }}"
     DirectoryIndex          index.html

--- a/roles/common/files/etc_apache2_conf-available_ssl-stapling-cache.conf
+++ b/roles/common/files/etc_apache2_conf-available_ssl-stapling-cache.conf
@@ -1,1 +1,0 @@
-SSLStaplingCache shmcb:${APACHE_RUN_DIR}/stapling_cache(128000)

--- a/roles/common/files/etc_apache2_conf-available_ssl.conf
+++ b/roles/common/files/etc_apache2_conf-available_ssl.conf
@@ -1,8 +1,8 @@
-SSLEngine on
 SSLProtocol ALL -SSLv2 -SSLv3
 SSLHonorCipherOrder On
 SSLCompression off
 SSLUseStapling On
+SSLStaplingCache shmcb:${APACHE_RUN_DIR}/stapling_cache(128000)
 SSLStaplingResponderTimeout 5
 SSLStaplingReturnResponderErrors off
 

--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -43,25 +43,13 @@
   notify: restart apache
   when: ansible_distribution_release != 'wheezy'
 
-- name: Add Apache SSL stapling cache configuration
-  copy:
-    src=etc_apache2_conf-available_ssl-stapling-cache.conf
-    dest=/etc/apache2/conf-available/ssl-stapling-cache.conf
-    owner=root
-    group=root
-  when: ansible_distribution_release != 'wheezy'
-  notify: restart apache
-
-- name: Enable Apache SSL stapling cache configuration
-  command: a2enconf ssl-stapling-cache
-    creates=/etc/apache2/conf-enabled/ssl-stapling-cache.conf
-  when: ansible_distribution_release != 'wheezy'
-  notify: restart apache
-
 - name: Add common Apache SSL config
-  template:
-    src=etc_apache2_ssl.conf.j2
-    dest=/etc/apache2/ssl.conf
+  copy: src=etc_apache2_conf-available_ssl.conf
+    dest=/etc/apache2/conf-available/ssl.conf
     owner=root
     group=root
+  notify: restart apache
+
+- name: Enable Apache SSL config
+  command: a2enconf ssl creates=/etc/apache2/conf-enabled/ssl.conf
   notify: restart apache

--- a/roles/git/templates/etc_apache2_sites-available_cgit.j2
+++ b/roles/git/templates/etc_apache2_sites-available_cgit.j2
@@ -6,10 +6,9 @@
 
 <VirtualHost *:443>
     ServerName {{ cgit_domain }}
+    SSLEngine On
 
-    Include /etc/apache2/ssl.conf
     DocumentRoot /var/www/htdocs/cgit/
-
     <Directory "/var/www/htdocs/cgit/">
         AllowOverride None
         Options +ExecCGI

--- a/roles/mailserver/templates/etc_apache2_sites-available_autoconfig.j2
+++ b/roles/mailserver/templates/etc_apache2_sites-available_autoconfig.j2
@@ -17,8 +17,7 @@
 
 <VirtualHost *:443>
     ServerName {{ mail_server_autoconfig_hostname }}
-
-    Include /etc/apache2/ssl.conf
+    SSLEngine On
 
     DocumentRoot            "/var/www/autoconfig"
     Options                 -Indexes

--- a/roles/news/templates/etc_apache2_sites-available_selfoss.j2
+++ b/roles/news/templates/etc_apache2_sites-available_selfoss.j2
@@ -6,8 +6,7 @@
 
 <VirtualHost *:443>
     ServerName {{ selfoss_domain }}
-
-    Include /etc/apache2/ssl.conf
+    SSLEngine On
 
     DocumentRoot            /var/www/selfoss
     Options                 -Indexes

--- a/roles/owncloud/templates/etc_apache2_sites-available_owncloud.j2
+++ b/roles/owncloud/templates/etc_apache2_sites-available_owncloud.j2
@@ -6,8 +6,7 @@
 
 <VirtualHost *:443>
     ServerName {{ owncloud_domain }}
-
-    Include /etc/apache2/ssl.conf
+    SSLEngine On
 
     DocumentRoot            /var/www/owncloud
     Options                 -Indexes

--- a/roles/readlater/templates/etc_apache2_sites-available_wallabag.j2
+++ b/roles/readlater/templates/etc_apache2_sites-available_wallabag.j2
@@ -6,8 +6,7 @@
 
 <VirtualHost *:443>
     ServerName {{ wallabag_domain }}
-
-    Include /etc/apache2/ssl.conf
+    SSLEngine On
 
     DocumentRoot            /var/www/wallabag
     Options                 -Indexes


### PR DESCRIPTION
To improve maintainability, avoid using the Include directive.  Move most of the SSL configuration to the global configuration and leave enabling the SSL engine to each virtual host that wants to use it.