### PR TITLE
Remove references to Trusty and Wheezy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Make sure you agree with the license (GPLv3). See [LICENSE.md](./LICENSE.md) for details.
 
-Code that is committed to the master branch should work with both Debian 8 "Jessie" and Ubuntu 14.04 LTS "Trusty".
+Code that is committed to the master branch should work with both Debian 8 "Jessie" (and Ubuntu 16.04 LTS "Xenial" once it is available).
 
 ## Development environment
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ What do you get if you point Sovereign at a server? All kinds of good stuff!
 -   [IMAP](https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol) over SSL via [Dovecot](http://dovecot.org/), complete with full text search provided by [Solr](https://lucene.apache.org/solr/).
 -   [POP3](https://en.wikipedia.org/wiki/Post_Office_Protocol) over SSL, also via Dovecot
 -   [SMTP](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol) over SSL via Postfix, including a nice set of [DNSBLs](https://en.wikipedia.org/wiki/DNSBL) to discard spam before it ever hits your filters.
--   Webmail via [Roundcube](http://www.roundcube.net/). **NOTE:** currently [only available on Ubuntu Trusty](http://forums.debian.net/viewtopic.php?f=10&t=121928).
+-   Webmail via [Roundcube](http://www.roundcube.net/). **NOTE:** currently unavailable.
 -   Mobile push notifications via [Z-Push](http://z-push.sourceforge.net/soswp/index.php?pages_id=1&t=home).
 -   Email client [automatic configuration](https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration).
 -   Jabber/[XMPP](http://xmpp.org/) instant messaging via [Prosody](http://prosody.im/).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,8 +36,8 @@ Vagrant.configure('2') do |config|
     jessie.vm.box = 'box-cutter/debian81'
   end
 
-  # Ubuntu 14.04.2 (LTS) 64-bit
-  config.vm.define 'trusty', autostart: false do |trusty|
-    trusty.vm.box = 'box-cutter/ubuntu1404'
+  # Ubuntu 16.04 (LTS) 64-bit (currently unavailable)
+  config.vm.define 'xenial', autostart: false do |xenial|
+    xenial.vm.box = 'box-cutter/ubuntu1604'
   end
 end

--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -41,7 +41,6 @@
   command: a2enmod socache_shmcb
     creates=/etc/apache2/mods-enabled/socache_shmcb.load
   notify: restart apache
-  when: ansible_distribution_release != 'wheezy'
 
 - name: Add Apache SSL stapling cache configuration
   copy:

--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -10,15 +10,8 @@
   tags:
     - dependencies
 
-- name: Install Postgres 9.3 for Dovecot on Ubuntu Trusty
-  apt: pkg=postgresql-9.3 state=present
-  when: ansible_distribution_release == 'trusty'
-  tags:
-    - dependencies
-
-- name: Install Postgres 9.4 for Dovecot on Debian Jessie
-  apt: pkg=postgresql-9.4 state=present
-  when: ansible_distribution_release == 'jessie'
+- name: Install Postgres for Dovecot
+  apt: pkg=postgresql state=present
   tags:
     - dependencies
 

--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -1,12 +1,5 @@
-- name: Install Postgres 9.3 on Ubuntu Trusty
-  apt: pkg=postgresql-9.3 state=present
-  when: ansible_distribution_release == 'trusty'
-  tags:
-    - dependencies
-
-- name: Install Postgres 9.4 on Debian Jessie
-  apt: pkg=postgresql-9.4 state=present
-  when: ansible_distribution_release == 'jessie'
+- name: Install Postgres
+  apt: pkg=postgresql state=present
   tags:
     - dependencies
 

--- a/roles/mailserver/tasks/rspamd.yml
+++ b/roles/mailserver/tasks/rspamd.yml
@@ -1,29 +1,15 @@
 ---
 # Installs and configures the Rspamd spam filtering system.
 
-- name: Ensure repository key for Rspamd is in place for Debian Jessie
+- name: Ensure repository key for Rspamd is in place
   apt_key: url=http://download.opensuse.org/repositories/home:cebka/Debian_8.0/Release.key state=present
   tags:
     - dependencies
-  when: ansible_distribution_release == 'jessie'
 
-- name: Ensure repository key for Rspamd is in place for Ubuntu Trusty
-  apt_key: url=http://download.opensuse.org/repositories/home:cebka/xUbuntu_14.10/Release.key state=present
-  tags:
-    - dependencies
-  when: ansible_distribution_release == 'trusty'
-
-- name: Add Rspamd repository for Debian Jesse
+- name: Add Rspamd repository
   apt_repository: repo="deb http://download.opensuse.org/repositories/home:/cebka/Debian_8.0/ /"
   tags:
     - dependencies
-  when: ansible_distribution_release == 'jessie'
-
-- name: Add Rspamd repository for Ubuntu Trusty
-  apt_repository: repo="deb http://download.opensuse.org/repositories/home:/cebka/xUbuntu_14.10/ /"
-  tags:
-    - dependencies
-  when: ansible_distribution_release == 'jessie'
 
 - name: Install Rspamd and Rmilter
   apt: pkg={{ item }} state=installed update_cache=yes

--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -41,22 +41,12 @@
 - name: Copy z-push's config.php into place
   template: src=usr_share_z-push_config.php.j2 dest=/usr/share/z-push/config.php
 
-- name: Configure z-push apache alias and php settings
-  copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf.d/z-push.conf
-  notify: restart apache
-  when: ansible_distribution_release != 'trusty' and ansible_distribution_release != 'jessie'
-
-
-- name: Create z-push apache alias and php configuration file for Ubuntu Trusty / jessie
+- name: Create z-push apache alias and php configuration file
   copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf-available/z-push.conf
-  when: ansible_distribution_release == 'trusty' or ansible_distribution_release == 'jessie'
 
-
-- name: Enable z-push Apache alias and PHP configuration file for Ubuntu Trusty / jessie
+- name: Enable z-push Apache alias and PHP configuration file
   command: a2enconf z-push creates=/etc/apache2/conf-enabled/z-push.conf
   notify: restart apache
-  when: ansible_distribution_release == 'trusty' or ansible_distribution_release == 'jessie'
-
 
 - name: Configure z-push logrotate
   copy: src=etc_logrotate_z-push dest=/etc/logrotate.d/z-push owner=root group=root mode=0644

--- a/roles/owncloud/tasks/owncloud.yml
+++ b/roles/owncloud/tasks/owncloud.yml
@@ -20,27 +20,13 @@
 - name: Create database for ownCloud
   postgresql_db: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ owncloud_db_database }} state=present owner={{ owncloud_db_username }}
 
-- name: Ensure repository key for ownCloud is in place for Debian Jesse
+- name: Ensure repository key for ownCloud is in place
   apt_key: url=http://download.opensuse.org/repositories/isv:ownCloud:community/Debian_8.0/Release.key state=present
-  when: ansible_distribution_release == 'jessie'
   tags:
     - dependencies
 
-- name: Add ownCloud OpenSuSE repository for Debian Jessie
+- name: Add ownCloud OpenSuSE repository
   apt_repository: repo='deb http://download.opensuse.org/repositories/isv:/ownCloud:/community/Debian_8.0/ /'
-  when: ansible_distribution_release == 'jessie'
-  tags:
-    - dependencies
-
-- name: Ensure repository key for ownCloud is in place for Ubuntu Trusty
-  apt_key: url=http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_14.04/Release.key state=present
-  when: ansible_distribution_release == 'trusty'
-  tags:
-    - dependencies
-
-- name: Add ownCloud OpenSuSE repository for Ubuntu Trusty
-  apt_repository: repo='deb http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_14.04/ /'
-  when: ansible_distribution_release == 'trusty'
   tags:
     - dependencies
 

--- a/roles/webmail/tasks/main.yml
+++ b/roles/webmail/tasks/main.yml
@@ -1,2 +1,1 @@
 - include: roundcube.yml tags=roundcube
-  when: ansible_distribution_release == 'trusty'

--- a/site.yml
+++ b/site.yml
@@ -12,7 +12,6 @@
   roles:
     - common
     - mailserver
-    - webmail
     - blog
     - ircbouncer
     - xmpp


### PR DESCRIPTION
Make a clean distinction between Debian 7 and Debian 8.  Anticipate the next Ubuntu LTS release (Xenial) that is planned for support.