### PR TITLE
Fix systemd configuration of OpenVPN server

### DIFF
--- a/roles/vpn/handlers/main.yml
+++ b/roles/vpn/handlers/main.yml
@@ -2,4 +2,4 @@
   service: name=dnsmasq state=restarted
 
 - name: restart openvpn
-  service: name=openvpn state=restarted
+  service: name=openvpn@server state=restarted

--- a/roles/vpn/tasks/openvpn.yml
+++ b/roles/vpn/tasks/openvpn.yml
@@ -141,6 +141,13 @@
   template: src=etc_openvpn_server.conf.j2 dest=/etc/openvpn/server.conf
   notify: restart openvpn
 
+- name: Copy OpenVPN PAM configuration file into place
+  copy: src=etc_pam.d_openvpn dest=/etc/pam.d/openvpn
+  notify: restart openvpn
+
+- name: Enable OpenVPN server systemd service unit
+  service: name=openvpn@server enabled=yes
+
 # OpenVPN must restart first so the 10.8.0.0 interface is available
 # to dnsmasq
 - meta: flush_handlers
@@ -148,10 +155,6 @@
 - name: Copy dnsmasq configuration file into place
   copy: src=etc_dnsmasq.conf dest=/etc/dnsmasq.conf
   notify: restart dnsmasq
-
-- name: Copy OpenVPN PAM configuration file into place
-  copy: src=etc_pam.d_openvpn dest=/etc/pam.d/openvpn
-  notify: restart openvpn
 
 - name: Copy the ca.crt and ta.key files that clients will need in order to connect to the OpenVPN server
   command: cp {{ openvpn_path }}/{{ item[1] }} {{ openvpn_path }}/{{ item[0] }}


### PR DESCRIPTION
This addresses Issue #475.  Runs under Vagrant.

The server was not starting.  As a result, the dnsmasq service failed to
start, and the playbook thus failed to run when using the vpn role.  This
patch corrects the configuration per instructions from
https://help.ubuntu.com/community/OpenVPN.

OpenVPN PAM configuration moved up to reduce server bouncing as the
playbook runs.  The dependency on service (re)starts between openvpn and
dnsmasq works but feels brittle.