### PR TITLE
Remove stray + prefix in sudoers file.

### DIFF
--- a/roles/common/templates/sudoers.j2
+++ b/roles/common/templates/sudoers.j2
@@ -1,1 +1,1 @@
-+{{ main_user_name }} ALL=(ALL) NOPASSWD: ALL
+{{ main_user_name }} ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
This `+` prefix in the `/etc/sudoers.d/sudoers` file created by Sovereign prevented my main user from actually being able to sudo. Per the sudoers man page, a `+` prefix indicates a "netgroup" -- but this is clearly a user name, not a netgroup, so I'm not sure why the `+` is there. Removing it allowed my user to sudo.