### PR TITLE
Make OpenDMARC cron job log everything instead of mailing some output to root.

### DIFF
--- a/roles/mailserver/tasks/opendmarc.yml
+++ b/roles/mailserver/tasks/opendmarc.yml
@@ -38,5 +38,4 @@
   file: path=/var/run/opendmarc/opendmarc.dat state=touch owner=opendmarc group=opendmarc
 
 - name: Activate OpenDMARC report cronjob
-  cron: name="OpenDMARC report" hour="2" minute="0" job="/bin/bash /etc/opendmarc/report.sh >> /var/log/opendmarc_report.log"
-
+  cron: name="OpenDMARC report" hour="2" minute="0" job="/bin/bash /etc/opendmarc/report.sh >> /var/log/opendmarc_report.log 2>&1 || tail /var/log/opendmarc_report.log"

--- a/roles/mailserver/templates/etc_opendmarc_report.sh.j2
+++ b/roles/mailserver/templates/etc_opendmarc_report.sh.j2
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# ensure this script errors out if any of its steps do
+set -e
+
 DB_SERVER='localhost'
 DB_USER='{{ mail_db_opendmarc_username }}'
 DB_PASS='{{ mail_db_opendmarc_password }}'


### PR DESCRIPTION
With current code in jessie, I get this daily email from cron to `root@mydomain`:

```
opendmarc-import: started at Tue Mar  8 02:00:02 2016
opendmarc-import: connected to database
opendmarc-import: updating at line 19
opendmarc-import: updating at line 36
opendmarc-import: terminating at Tue Mar  8 02:00:02 2016
opendmarc-reports: started at Tue Mar  8 02:00:02 2016
opendmarc-reports: selected 1 domain(s)
opendmarc-reports: terminating at Tue Mar  8 02:00:02 2016
opendmarc-expire: started at Tue Mar  8 02:00:02 2016
opendmarc-expire: connected to database
opendmarc-expire: expiring messages older than 180 day(s)
opendmarc-expire: expiring signatures on expired messages (id < 1)
opendmarc-expire: expiring request data older than 180 days
opendmarc-expire: terminating at Tue Mar  8 02:00:02 2016
```

It looks like the opendmarc report cron job is supposed to send its output to `/var/log/opendmarc_report.log`, but it's currently redirecting only stdout, not stderr, so the stderr output gets mailed to me.

Is this intentional? Is this a report that I should be carefully reading each day?

Assuming it's not intentional, this PR redirects stderr as well, so all output goes to the log file and nothing gets mailed to root.