### PR TITLE
Pass {auth_type} to milters, fixing OpenDKIM signing of authenticated SMTP messages.

### DIFF
--- a/roles/mailserver/templates/etc_postfix_main.cf.j2
+++ b/roles/mailserver/templates/etc_postfix_main.cf.j2
@@ -104,7 +104,7 @@ local_recipient_maps = $virtual_mailbox_maps
 smtpd_milters = inet:127.0.0.1:8891,inet:127.0.0.1:54321,unix:/var/run/rmilter/rmilter.sock
 non_smtpd_milters = $smtpd_milters
 milter_protocol = 6
-milter_mail_macros = i {mail_addr} {client_addr} {client_name} {auth_authen}
+milter_mail_macros = i {mail_addr} {client_addr} {client_name} {auth_authen} {auth_type}
 milter_default_action = accept
 
 smtpd_client_restrictions = permit_sasl_authenticated


### PR DESCRIPTION
Fixes #510 (and fixes a failing test).