### PR TITLE
Remove unused variables in jessie

### DIFF
--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -40,15 +40,11 @@ collectd_librato_version: 0.0.10
 collectd_librato_email: "" # (optional)
 collectd_librato_api_token: "" # (optional)
 
-# google authenticator
-google_auth_version: 1.0
-
 # database
 db_admin_username: 'postgres'
 # db_admin_password: (required)
 
 # ircbouncer
-znc_version: 1.4
 # irc_nick: (required)
 # irc_ident: (required)
 # irc_realname: (required)


### PR DESCRIPTION
google_auth_version is not used in jessie, neither is znc_version