### PR TITLE
Complete rmilter/rspamd setup.

### DIFF
--- a/roles/mailserver/files/etc_rmilter.conf.common
+++ b/roles/mailserver/files/etc_rmilter.conf.common
@@ -1,0 +1,12 @@
+spamd {
+	servers = r:localhost:11333;
+	whitelist = 127.0.0.1/32, 192.168.0.0/16, [::1]/128;
+};
+
+redis {
+	servers_id = localhost;
+	id_prefix = "message_id.";
+};
+
+tempdir = /tmp;
+max_size = 10M;

--- a/roles/mailserver/files/lib_systemd_system_rmilter.socket
+++ b/roles/mailserver/files/lib_systemd_system_rmilter.socket
@@ -1,0 +1,8 @@
+[Unit]
+Description=Another sendmail milter for different mail checks
+
+[Socket]
+ListenStream=9900
+
+[Install]
+WantedBy=sockets.target

--- a/roles/mailserver/tasks/rspamd.yml
+++ b/roles/mailserver/tasks/rspamd.yml
@@ -11,10 +11,26 @@
   tags:
     - dependencies
 
-- name: Install Rspamd and Rmilter
+- name: Install Rspamd, Rmilter, and Redis
   apt: pkg={{ item }} state=installed update_cache=yes
   with_items:
     - rspamd
     - rmilter
+    - redis-server
   tags:
     - dependencies
+
+- name: Configure rmilter
+  copy: src=etc_rmilter.conf.common dest=/etc/rmilter.conf.common
+
+- name: Configure rmilter socket service
+  copy: src=lib_systemd_system_rmilter.socket dest=/lib/systemd/system/rmilter.socket
+
+- name: Start redis
+  service: name=redis-server state=started
+
+- name: Start rspamd systemd socket listener
+  service: name=rspamd.socket state=started
+
+- name: Start rmilter systemd socket listener
+  service: name=rmilter.socket state=started

--- a/roles/mailserver/templates/etc_postfix_main.cf.j2
+++ b/roles/mailserver/templates/etc_postfix_main.cf.j2
@@ -101,7 +101,7 @@ virtual_alias_maps = pgsql:/etc/postfix/pgsql-virtual-alias-maps.cf
 local_recipient_maps = $virtual_mailbox_maps
 
 # Milters: OpenDKIM, OpenDMARC, Rspamd
-smtpd_milters = inet:127.0.0.1:8891,inet:127.0.0.1:54321,unix:/var/run/rmilter/rmilter.sock
+smtpd_milters = inet:127.0.0.1:8891,inet:127.0.0.1:54321,inet:127.0.0.1:9900
 non_smtpd_milters = $smtpd_milters
 milter_protocol = 6
 milter_mail_macros = i {mail_addr} {client_addr} {client_name} {auth_authen} {auth_type}


### PR DESCRIPTION
This gets rspamd hooked up to postfix via rmilter.

Rmilter has a bunch of other capabilities that could be explored in the future (including the ability to do DKIM signing and verification, so we wouldn't need to have Postfix talk directly to OpenDKIM as a separate milter), but this PR only sets it up for rspamd.

The `rmilter.socket` systemd unit file has to be replaced because the default unit file uses a Unix socket instead of a TCP socket, and (as discussed at https://github.com/vstakhov/rmilter/issues/39) this doesn't play nicely with postfix running smtpd in a chroot. The author of rmilter recommends just using a TCP socket instead.