### PR TITLE
openvpn: only CN needed for openssl certificate

### DIFF
--- a/group_vars/sovereign
+++ b/group_vars/sovereign
@@ -51,11 +51,6 @@ prosody_accounts:
     password: TODO
 
 # openvpn
-openvpn_key_country:  "US"
-openvpn_key_province: "California"
-openvpn_key_city: "Beverly Hills"
-openvpn_key_org: "ACME CORPORATION"
-openvpn_key_ou: "Anvil Department"
 openvpn_clients:
   - laptop
   - phone

--- a/roles/vpn/tasks/openvpn.yml
+++ b/roles/vpn/tasks/openvpn.yml
@@ -38,7 +38,7 @@
         mode=0600
 
 - name: Generate CA certificate
-  command: openssl req -nodes -batch -new -x509 -key {{ openvpn_ca }}.key -out {{ openvpn_ca }}.crt -days {{ openvpn_days_valid }} -subj "{{ openssl_request_subject }}/CN=ca-certificate"
+  command: openssl req -nodes -batch -new -x509 -key {{ openvpn_ca }}.key -out {{ openvpn_ca }}.crt -days {{ openvpn_days_valid }} -subj "{{ openssl_request_subject }}/CN=sovereign-ca-certificate"
            creates={{ openvpn_ca }}.crt
 
 - name: Generate the OpenSSL configuration that will be used for the Server certificate's req and ca commands

--- a/roles/vpn/templates/openssl-server-certificate.cnf.j2
+++ b/roles/vpn/templates/openssl-server-certificate.cnf.j2
@@ -39,19 +39,14 @@ distinguished_name = req_distinguished_name
 
 [ req_distinguished_name ]
 countryName = Country Name (2 letter code)
-countryName_default = {{ openvpn_key_country }}
 
 stateOrProvinceName = State or Province Name (full name)
-stateOrProvinceName_default = {{ openvpn_key_province }}
 
 localityName = Locality Name (eg, city)
-localityName_default = {{ openvpn_key_city }}
 
 0.organizationName = Organization Name (eg, company)
-0.organizationName_default = {{ openvpn_key_org }}
 
 organizationalUnitName = Organizational Unit Name (eg, section)
-organizationalUnitName_default = {{ openvpn_key_ou }}
 
 commonName = Common Name (eg, your name or your server\'s hostname)
 commonName_default = server


### PR DESCRIPTION
There is no requirement, AFAIK, that a self-signed x509 certificate contain any
information other than common name (CN). Requiring users to provide county, state, city, etc. is inconvenient and, if I have this right, unnecessary.