### PR TITLE
Idempotency fixes to LetsEncrypt handling.

### DIFF
--- a/roles/common/files/etc_cron-monthly_letsencrypt-renew
+++ b/roles/common/files/etc_cron-monthly_letsencrypt-renew
@@ -18,5 +18,8 @@ for c in $(find /etc/letsencrypt/live/ -mindepth 1  -type d); do
 done
 service apache2 start
 
-# Services that rely on LE certificates will need restarted.
-
+# Services that rely on LE certificates may need restarted and/or other actions.
+for script in $(find /etc/letsencrypt/postrenew/ -maxdepth 1 -type f); do
+  echo "Executing ${script}."
+  $script
+done

--- a/roles/common/files/etc_cron-monthly_letsencrypt-renew
+++ b/roles/common/files/etc_cron-monthly_letsencrypt-renew
@@ -19,7 +19,7 @@ done
 service apache2 start
 
 # Services that rely on LE certificates may need restarted and/or other actions.
-for script in $(find /etc/letsencrypt/postrenew/ -maxdepth 1 -type f); do
+for script in $(find /etc/letsencrypt/postrenew/ -maxdepth 1 -type f -executable); do
   echo "Executing ${script}."
   $script
 done

--- a/roles/common/files/letsencrypt-gencert
+++ b/roles/common/files/letsencrypt-gencert
@@ -1,4 +1,5 @@
 #!/bin/bash
+service apache2 stop
 d="$1"
 for i in www mail autoconfig read news cloud git; do
   if (getent hosts $i.$1 > /dev/null); then

--- a/roles/common/files/letsencrypt-gencert
+++ b/roles/common/files/letsencrypt-gencert
@@ -5,6 +5,9 @@ for i in www mail autoconfig read news cloud git; do
     d="$d,$i.$1";
   fi
 done
+# We are using the "standalone" letsencrypt plugin, which runs its own
+# webserver, so we need to temporarily free up the HTTP(S) ports by stopping
+# our own Apache.
 service apache2 stop
 /root/letsencrypt/letsencrypt-auto certonly -c /etc/letsencrypt/cli.conf --domains $d
 service apache2 start

--- a/roles/common/files/letsencrypt-gencert
+++ b/roles/common/files/letsencrypt-gencert
@@ -1,9 +1,10 @@
 #!/bin/bash
-service apache2 stop
 d="$1"
 for i in www mail autoconfig read news cloud git; do
   if (getent hosts $i.$1 > /dev/null); then
     d="$d,$i.$1";
   fi
 done
+service apache2 stop
 /root/letsencrypt/letsencrypt-auto certonly -c /etc/letsencrypt/cli.conf --domains $d
+service apache2 start

--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -33,9 +33,6 @@
 - name: Create live directory for LetsEncrypt cron job
   file: state=directory path=/etc/letsencrypt/live group=root owner=root
 
-- name: Stop Apache
-  service: name=apache2 state=stopped
-
 - name: Get an SSL certificate for {{ domain }} from Let's Encrypt
   script: letsencrypt-gencert {{ domain }} creates=/etc/letsencrypt/live/{{ domain }}/privkey.pem
   when: ansible_ssh_user != "vagrant"

--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -83,6 +83,3 @@
   when: ansible_ssh_user == "vagrant"
 
 ### Back to normal
-
-- name: Start Apache
-  service: name=apache2 state=started

--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -16,6 +16,8 @@
 
 - name: Install LetsEncrypt package dependencies
   command: /root/letsencrypt/letsencrypt-auto --help
+  register: le_deps_result
+  changed_when: "'Bootstrapping dependencies' in le_deps_result.stdout"
 
 - name: Create directory for post-renewal scripts
   file: state=directory path=/etc/letsencrypt/postrenew group=root owner=root

--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -37,9 +37,7 @@
   service: name=apache2 state=stopped
 
 - name: Get an SSL certificate for {{ domain }} from Let's Encrypt
-  script: letsencrypt-gencert {{ domain }}
-  args:
-    creates: /etc/letsencrypt/live/{{ domain }}/privkey.pem
+  script: letsencrypt-gencert {{ domain }} creates=/etc/letsencrypt/live/{{ domain }}/privkey.pem
   when: ansible_ssh_user != "vagrant"
 
 - name: Modify permissions to allow ssl-cert group access

--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -17,6 +17,9 @@
 - name: Install LetsEncrypt package dependencies
   command: /root/letsencrypt/letsencrypt-auto --help
 
+- name: Create directory for post-renewal scripts
+  file: state=directory path=/etc/letsencrypt/postrenew group=root owner=root
+
 - name: Install crontab entry for LetsEncrypt
   copy:
     src=etc_cron-monthly_letsencrypt-renew

--- a/roles/ircbouncer/tasks/znc.yml
+++ b/roles/ircbouncer/tasks/znc.yml
@@ -24,10 +24,13 @@
     creates=/usr/lib/znc/znc.pem
   notify: restart znc
 
-- name: Update certificate renwal cron job
-  lineinfile: dest=/etc/cron.monthly/letsencrypt-renew state=present
-    line="cat /etc/letsencrypt/live/{{ domain }}/{privkey,fullchain}.pem > /usr/lib/znc/znc.pem; chown znc.znc /usr/lib/znc/znc.pem; chmod 640 /usr/lib/znc/znc.pem; service znc restart"
-    insertafter="EOF"
+- name: Update post-certificate-renewal task
+  template:
+    src: etc_letsencrypt_postrenew_znc.sh.j2
+    dest: /etc/letsencrypt/postrenew/znc.sh
+    owner: root
+    group: root
+    mode: 0755
 
 - name: Ensure znc user and group can read cert
   file: path=/usr/lib/znc/znc.pem group=znc owner=znc mode=640

--- a/roles/ircbouncer/templates/etc_letsencrypt_postrenew_znc.sh.j2
+++ b/roles/ircbouncer/templates/etc_letsencrypt_postrenew_znc.sh.j2
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Executed by /etc/cron.monthly/letsencrypt-renew
+
+cat /etc/letsencrypt/live/{{ domain }}/{privkey,fullchain}.pem > /usr/lib/znc/znc.pem
+chown znc.znc /usr/lib/znc/znc.pem
+chmod 640 /usr/lib/znc/znc.pem
+service znc restart

--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -65,7 +65,10 @@
     - pop3s
   tags: ufw
 
-- name: Update certificate renwal cron job
-  lineinfile: dest=/etc/cron.monthly/letsencrypt-renew state=present
-    line="service dovecot restart"
-    insertafter="EOF"
+- name: Update post-certificate-renewal task
+  copy:
+    content: "#!/bin/bash\n\nservice dovecot restart\n"
+    dest: /etc/letsencrypt/postrenew/dovecot.sh
+    mode: 0755
+    owner: root
+    group: root


### PR DESCRIPTION
Previous to this PR, because the ZNC and dovecot roles were modifying the LetsEncrypt renewal cron job in place, every subsequent run would reinstall the original version of that cron job. This causes spurious "changed" tasks, as well as problems if e.g. the LetsEncrypt tasks are run outside of a full run (because the cronjob will be restored to its non-updated form). This PR fixes that by making each post-renew task an independent script, found and executed by the cronjob. Tested and working.