### PR TITLE
Workaround bug with enabling SysV init scripts on Jessie.

### DIFF
--- a/roles/common/tasks/ntp.yml
+++ b/roles/common/tasks/ntp.yml
@@ -11,6 +11,10 @@
   notify:
     - restart ntp
 
-- name: Ensure ntpd is running and enabled
-  service: name=ntp state=started enabled=yes
+- name: Ensure ntpd is running
+  service: name=ntp state=started
 
+# Work around https://github.com/ansible/ansible-modules-core/issues/915
+# otherwise we'd use enabled=yes in previous task
+- name: Ensure ntp is enabled
+  command: update-rc.d ntp enable creates=/etc/rc3.d/S03ntp

--- a/roles/monitoring/tasks/collectd.yml
+++ b/roles/monitoring/tasks/collectd.yml
@@ -5,5 +5,10 @@
   template: src=etc_collectd_collectd.conf.j2 dest=/etc/collectd/collectd.conf
   notify: restart collectd
 
-- name: Ensure collectd is a system service
-  service: name=collectd state=started enabled=true
+- name: Ensure collectd is started
+  service: name=collectd state=started
+
+# Work around https://github.com/ansible/ansible-modules-core/issues/915
+# otherwise we'd use enabled=yes in previous task
+- name: Ensure collectd is enabled
+  command: update-rc.d collectd enable creates=/etc/rc3.d/S03collectd


### PR DESCRIPTION
Without this PR in Jessie, the `enabled=yes` arg on the ntp service task has no effect and always reports `changed: true`, due to https://github.com/ansible/ansible-modules-core/issues/915

This PR works around that bug to actually ensure that NTP is enabled and fix the changed reporting.