### PR TITLE
Encrypt Postgres passwords, and fix change-reporting.

### DIFF
--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -16,7 +16,7 @@
   tags:
     - dependencies
 
-- name: Set postgres user password
+- name: Set password for PostgreSQL admin user
   become: true
   become_user: postgres
   postgresql_user: name={{ db_admin_username }} password={{ db_admin_password }} encrypted=yes

--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -16,12 +16,14 @@
   tags:
     - dependencies
 
-- name: Set postgres password
-  command: sudo -u {{ db_admin_username }} psql -d {{ db_admin_username }} -c "ALTER USER postgres with  password '{{ db_admin_password }}';"
+- name: Set postgres user password
+  become: true
+  become_user: postgres
+  postgresql_user: name={{ db_admin_username }} password={{ db_admin_password }} encrypted=yes
   notify: import sql postfix
 
 - name: Create database user for mail server
-  postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ mail_db_username }} password="{{ mail_db_password }}" state=present
+  postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ mail_db_username }} password="{{ mail_db_password }}" encrypted=yes state=present
   notify: import sql postfix
 
 - name: Create database for mail server

--- a/roles/owncloud/tasks/owncloud.yml
+++ b/roles/owncloud/tasks/owncloud.yml
@@ -9,8 +9,10 @@
   tags:
     - dependencies
 
-- name: Set postgres administrator password
-  command: sudo -u {{ db_admin_username }} psql -c "ALTER USER postgres with password '{{ db_admin_password }}';"
+- name: Set password for PostgreSQL admin user
+  become: true
+  become_user: postgres
+  postgresql_user: name={{ db_admin_username }} password={{ db_admin_password }} encrypted=yes
 
 - name: Create database user for ownCloud
   postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ owncloud_db_username }} password="{{ owncloud_db_password }}" role_attr_flags=CREATEDB state=present


### PR DESCRIPTION
This causes the Postgres role passwords to be encrypted rather than plaintext in the database.

It also uses the `postgresql_user` Ansible module to apply the change to the admin user's password; this fixes changed-reporting. (The previous version of that task always reported `changed: true`).