### PR TITLE
Idempotency/changed-reporting fixes for OpenDMARC tasks.

### DIFF
--- a/roles/mailserver/handlers/main.yml
+++ b/roles/mailserver/handlers/main.yml
@@ -19,3 +19,6 @@
 
 - name: restart rspamd
   service: name=rspamd.socket state=restarted
+
+- name: import opendmarc schema
+  mysql_db: name={{ mail_db_opendmarc_database }} state=import target=/usr/share/doc/opendmarc/schema.mysql

--- a/roles/mailserver/tasks/opendmarc.yml
+++ b/roles/mailserver/tasks/opendmarc.yml
@@ -26,16 +26,13 @@
 
 - name: Create database for OpenDMARC reports
   mysql_db: name={{ mail_db_opendmarc_database }} state=present
-
-- name: Import database schema for OpenDMARC reports
-  mysql_db: name={{ mail_db_opendmarc_database }} state=import target=/usr/share/doc/opendmarc/schema.mysql
-  tags: import_mysql_postfix
+  notify: import opendmarc schema
 
 - name: Copy nightly OpenDMARC report generation script into place
   template: src=etc_opendmarc_report.sh.j2 dest=/etc/opendmarc/report.sh owner=root group=root mode="755"
 
-- name: Touch initial report dat file with correct permissions
-  file: path=/var/run/opendmarc/opendmarc.dat state=touch owner=opendmarc group=opendmarc
+- name: Ensure initial report dat file exists with correct permissions
+  copy: content="" dest=/var/run/opendmarc/opendmarc.dat owner=opendmarc group=opendmarc
 
 - name: Activate OpenDMARC report cronjob
   cron: name="OpenDMARC report" hour="2" minute="0" job="/bin/bash /etc/opendmarc/report.sh >> /var/log/opendmarc_report.log 2>&1 || tail /var/log/opendmarc_report.log"


### PR DESCRIPTION
As discussed in https://groups.google.com/forum/#!msg/ansible-project/XrQ08TdtcRk/I4s7rF7GkyMJ the `mysql_db` module's `import` arg unconditionally re-runs the given SQL file, whether needed or not, and always reports `changed: true`. This PR only imports the schema after initially creating the database.

Similarly, the `file` module's `touch` arg updates the mtime and atime (which we don't need here) and always reports `changed: true`. Using `copy` instead with empty contents ensures the file exists with given ownership, but only returns `changed: true` if it was actually created or its ownership was changed.

With these changes, the OpenDMARC tasks run changed-clean for me.