### PR TITLE
Fix monitoring config for apache/postgresql.

### DIFF
--- a/roles/monitoring/files/etc_monit_conf.d_apache2
+++ b/roles/monitoring/files/etc_monit_conf.d_apache2
@@ -1,4 +1,4 @@
-check process apache2 with pidfile /var/run/apache2.pid
+check process apache2 with pidfile /var/run/apache2/apache2.pid
   group www
   start program = "systemctl start apache2"
   stop program = "systemctl stop apache2"

--- a/roles/monitoring/files/etc_monit_conf.d_pgsql
+++ b/roles/monitoring/files/etc_monit_conf.d_pgsql
@@ -1,4 +1,4 @@
-check process postgres with pidfile /var/run/postgresql/9.1-main.pid
+check process postgres with pidfile /var/run/postgresql/9.4-main.pid
   group database
   start program = "systemctl start postgresql"
   stop program = "systemctl stop postgresql"


### PR DESCRIPTION
I did a clean installation of a new Debian jessie server configured using sovereign. It looks like monit configuration for pgsql/apache doesn't check the correct process ``pid`` files.