### PR TITLE
Add non-interactive to LE client options

### DIFF
--- a/roles/common/templates/etc_letsencrypt_cli.conf.j2
+++ b/roles/common/templates/etc_letsencrypt_cli.conf.j2
@@ -5,3 +5,4 @@ register-unsafely-without-email = True
 keep = True
 expand = True
 agree-tos = True
+non-interactive = True


### PR DESCRIPTION
Depending on when the client is run, there are no certificates to
update.  By default, the client runs in interactive mode and wants to
notify the user of this.  This causes Ansible to hang waiting for an
acknowledgement that will never come.  Adding the non-interactive flag
fixes this.