### PR TITLE
Add leading 0 to octal file permissions

### DIFF
--- a/roles/common/tasks/encfs.yml
+++ b/roles/common/tasks/encfs.yml
@@ -25,4 +25,4 @@
   when: encfs_check.rc == 0
 
 - name: Set decrypted directory permissions
-  file: state=directory path=/decrypted group=mail mode=775
+  file: state=directory path=/decrypted group=mail mode=0775

--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -28,7 +28,7 @@
     dest=/etc/cron.monthly/letsencrypt-renew
     owner=root
     group=root
-    mode=755
+    mode=0755
 
 - name: Create live directory for LetsEncrypt cron job
   file: state=directory path=/etc/letsencrypt/live group=root owner=root
@@ -38,26 +38,26 @@
   when: ansible_ssh_user != "vagrant"
 
 - name: Modify permissions to allow ssl-cert group access
-  file: path=/etc/letsencrypt/archive owner=root group=ssl-cert mode=750
+  file: path=/etc/letsencrypt/archive owner=root group=ssl-cert mode=0750
   when: ansible_ssh_user != "vagrant"
 
 ### Several steps to install a self-signed wildcard key to support offline testing
 
 - name: Create live directory for testing keys
   file: dest=/etc/letsencrypt/live/{{ domain }} state=directory
-    owner=root group=root mode=755
+    owner=root group=root mode=0755
   when: ansible_ssh_user == "vagrant"
 
 - name: Copy SSL wildcard private key for testing
   copy: src=wildcard_private.key
     dest=/etc/letsencrypt/live/{{ domain }}/privkey.pem
-    owner=root group=ssl-cert mode=640
+    owner=root group=ssl-cert mode=0640
   when: ansible_ssh_user == "vagrant"
 
 - name: Copy SSL public certificate into place for testing
   copy: src=wildcard_public_cert.crt
     dest=/etc/letsencrypt/live/{{ domain }}/cert.pem
-    group=root owner=root mode=644
+    group=root owner=root mode=0644
   register: certificate
   notify: restart apache
   when: ansible_ssh_user == "vagrant"
@@ -65,7 +65,7 @@
 - name: Copy SSL CA combined certificate into place for testing
   copy: src=wildcard_ca.pem
     dest=/etc/letsencrypt/live/{{ domain }}/chain.pem
-    group=root owner=root mode=644
+    group=root owner=root mode=0644
   register: ca_certificate
   notify: restart apache
   when: ansible_ssh_user == "vagrant"
@@ -78,7 +78,7 @@
   when: ansible_ssh_user == "vagrant"
 
 - name: Set permissions on combined SSL public cert
-  file: name=/etc/letsencrypt/live/{{ domain }}/fullchain.pem mode=644
+  file: name=/etc/letsencrypt/live/{{ domain }}/fullchain.pem mode=0644
   notify: restart apache
   when: ansible_ssh_user == "vagrant"
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -57,7 +57,7 @@
   file: state=directory path=/decrypted
 
 - name: Set decrypted directory permissions
-  file: state=directory path=/decrypted group=mail mode=775
+  file: state=directory path=/decrypted group=mail mode=0775
 
 - include: encfs.yml tags=encfs
 - include: users.yml tags=users

--- a/roles/ircbouncer/tasks/znc.yml
+++ b/roles/ircbouncer/tasks/znc.yml
@@ -40,7 +40,7 @@
     mode: 0755
 
 - name: Ensure znc user and group can read cert
-  file: path=/usr/lib/znc/znc.pem group=znc owner=znc mode=640
+  file: path=/usr/lib/znc/znc.pem group=znc owner=znc mode=0640
   notify: restart znc
 
 - name: Check for existing config file

--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -22,7 +22,7 @@
   user: name=vmail group=vmail state=present uid=5000 home=/decrypted shell=/usr/sbin/nologin
 
 - name: Ensure mail domain directories are in place
-  file: state=directory path=/decrypted/{{ item.name }} owner=vmail group=dovecot mode=770
+  file: state=directory path=/decrypted/{{ item.name }} owner=vmail group=dovecot mode=0770
   with_items: mail_virtual_domains
 
 - name: Ensure mail directories are in place
@@ -55,7 +55,7 @@
 
 - name: Ensure correct permissions on Dovecot config directory
   file: state=directory path=/etc/dovecot
-          group=dovecot owner=vmail mode=770 recurse=yes
+          group=dovecot owner=vmail mode=0770 recurse=yes
   notify: restart dovecot
 
 - name: Set firewall rules for dovecot

--- a/roles/mailserver/tasks/opendkim.yml
+++ b/roles/mailserver/tasks/opendkim.yml
@@ -38,7 +38,7 @@
 
 - name: Set OpenDKIM config directory permissions
   file: state=directory path=/etc/opendkim
-          group=opendkim owner=opendkim mode=700 recurse=yes
+          group=opendkim owner=opendkim mode=0700 recurse=yes
   notify:
     - restart opendkim
     - restart postfix

--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -32,7 +32,7 @@
     - skip_ansible_lint
 
 - name: Ensure z-push state and log directories are in place
-  file: state=directory path={{ item }} owner=www-data group=www-data mode=755
+  file: state=directory path={{ item }} owner=www-data group=www-data mode=0755
   with_items:
     - /decrypted/zpush-state
     - /var/log/z-push

--- a/roles/vpn/tasks/openvpn.yml
+++ b/roles/vpn/tasks/openvpn.yml
@@ -35,7 +35,7 @@
         state=directory
         owner=root
         group=root
-        mode=600
+        mode=0600
 
 - name: Generate CA certificate
   command: openssl req -nodes -batch -new -x509 -key {{ openvpn_ca }}.key -out {{ openvpn_ca }}.crt -days {{ openvpn_days_valid }} -subj "{{ openssl_request_subject }}/CN=ca-certificate"
@@ -120,10 +120,10 @@
            creates={{ openvpn_dhparam }}
 
 - name: Add empty rc.local if it doesn't exist
-  copy: src=rc.local dest=/etc/rc.local mode=700 owner=root group=root force=no
+  copy: src=rc.local dest=/etc/rc.local mode=0700 owner=root group=root force=no
 
 - name: custom rc.local file with iptables rules
-  template: src=rc.local_ansible_openvpn dest=/etc/rc.local_ansible_openvpn mode=700 owner=root group=root
+  template: src=rc.local_ansible_openvpn dest=/etc/rc.local_ansible_openvpn mode=0700 owner=root group=root
 
 - name: Ensure custom rc.local file is included in rc.local
   lineinfile: dest=/etc/rc.local line='bash /etc/rc.local_ansible_openvpn' insertbefore='exit 0'


### PR DESCRIPTION
This is done to suppress warnings from ansible-lint.