### PR TITLE
Remove unnecessary ownCloud configuration

### DIFF
--- a/roles/owncloud/tasks/owncloud.yml
+++ b/roles/owncloud/tasks/owncloud.yml
@@ -39,14 +39,8 @@
   command: mv /var/www/owncloud/data /decrypted/owncloud-data creates=/decrypted/owncloud-data
 - file: src=/decrypted/owncloud-data dest=/var/www/owncloud/data owner=www-data group=www-data state=link
 
-- name: Remove conf-enabled/owncloud symlink
-  file: path=/etc/apache2/conf-enabled/owncloud.conf state=absent
-  notify: restart apache
-
-- name: Configure the Apache HTTP server for ownCloud
+- name: Configure Apache for ownCloud
   template: src=etc_apache2_sites-available_owncloud.j2 dest=/etc/apache2/sites-available/owncloud.conf group=root
-- name: Enable the owncloud site
-  command: a2ensite owncloud.conf creates=/etc/apache2/sites-enabled/owncloud.conf
   notify: restart apache
 
 - name: Install ownCloud cronjob


### PR DESCRIPTION
The ownCloud configuration file does not get touched.  The virtual host
configuration is modified by sovereign but can be updated in place and
Apache restarted.