### PR TITLE
Fix fail2ban dovecot config.

### DIFF
--- a/roles/common/templates/etc_fail2ban_jail.local.j2
+++ b/roles/common/templates/etc_fail2ban_jail.local.j2
@@ -28,7 +28,7 @@ maxretry = 1
 enabled = true
 filter = dovecot-pop3imap
 action = iptables-multiport[name=dovecot-pop3imap, port="pop3,imap,993,995", protocol=tcp]
-logpath = /var/log/maillog
+logpath = /var/log/mail.log
 maxretry = 20
 findtime = 1200
 bantime = 1200


### PR DESCRIPTION
The fail2ban config for dovecot was referring to a log file /var/log/maillog, which does not exist. It should be /var/log/mail.log. This causes fail2ban to fail to start. I only noticed because that in turn caused the post-rotate script for fail2ban's logrotate config to error out.