### PR TITLE
LE options fix

### DIFF
--- a/roles/common/files/etc_cron-monthly_letsencrypt-renew
+++ b/roles/common/files/etc_cron-monthly_letsencrypt-renew
@@ -1,21 +1,10 @@
 #!/bin/bash
 set -o errexit
+
 # Renew all live certificates with LetsEncrypt.  This needs to run at least
 # once every three months.
-
-# Given a certificate file returns "domain1,domain2"
-# https://community.letsencrypt.org/t/help-me-understand-renewal-config/7115
-function getDomains() {
-        openssl x509 -text -in "$1" |
-        grep -A1 "Subject Alternative Name:" | tail -n1 |
-        tr -d ' ' | tr -d 'DNS:'
-}
-
 service apache2 stop
-for c in $(find /etc/letsencrypt/live/ -mindepth 1  -type d); do
-  domains=$(getDomains "$c"/cert.pem)
-  /root/letsencrypt/letsencrypt-auto --renew certonly -c /etc/letsencrypt/cli.conf --domains=$domains
-done
+/root/letsencrypt/letsencrypt-auto renew -c /etc/letsencrypt/cli.conf
 service apache2 start
 
 # Services that rely on LE certificates may need restarted and/or other actions.


### PR DESCRIPTION
LE client no longer accepts lists of domains for certificate renewal and
instead renews all installed certificates due to be renewed.  This is
the behavior we want, and it simplifies the script.