### PR TITLE
Fixed LE renew options

### DIFF
--- a/roles/common/files/etc_cron-daily_letsencrypt-renew
+++ b/roles/common/files/etc_cron-daily_letsencrypt-renew
@@ -3,11 +3,6 @@ set -o errexit
 # Renew all live certificates with LetsEncrypt.  This needs to run at least
 # once every three months, but recommended frequency is once a day.
 
-/root/letsencrypt/letsencrypt-auto renew --pre-hook="service apache2 stop" --post-hook="service apache2 start" \
-    -c /etc/letsencrypt/cli.conf
-
-# Services that rely on LE certificates may need restarted and/or other actions.
-for script in $(find /etc/letsencrypt/postrenew/ -maxdepth 1 -type f -executable); do
-  echo "Executing ${script}."
-  $script
-done
+/root/letsencrypt/letsencrypt-auto renew -c /etc/letsencrypt/cli.conf \
+--pre-hook="find /etc/letsencrypt/prerenew/ -maxdepth 1 -type f -executable -exec {} \;" \
+--post-hook="find /etc/letsencrypt/postrenew/ -maxdepth 1 -type f -executable -exec {} \;"

--- a/roles/common/files/etc_cron-daily_letsencrypt-renew
+++ b/roles/common/files/etc_cron-daily_letsencrypt-renew
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o errexit
 # Renew all live certificates with LetsEncrypt.  This needs to run at least
-# once every three months, but recommanded frequency is once a day.
+# once every three months, but recommended frequency is once a day.
 
 /root/letsencrypt/letsencrypt-auto renew --pre-hook="service apache2 stop" --post-hook="service apache2 start" \
     -c /etc/letsencrypt/cli.conf

--- a/roles/common/files/etc_cron-monthly_letsencrypt-renew
+++ b/roles/common/files/etc_cron-monthly_letsencrypt-renew
@@ -1,22 +1,10 @@
 #!/bin/bash
 set -o errexit
 # Renew all live certificates with LetsEncrypt.  This needs to run at least
-# once every three months.
+# once every three months, but recommanded frequency is once a day.
 
-# Given a certificate file returns "domain1,domain2"
-# https://community.letsencrypt.org/t/help-me-understand-renewal-config/7115
-function getDomains() {
-        openssl x509 -text -in "$1" |
-        grep -A1 "Subject Alternative Name:" | tail -n1 |
-        tr -d ' ' | tr -d 'DNS:'
-}
-
-service apache2 stop
-for c in $(find /etc/letsencrypt/live/ -mindepth 1  -type d); do
-  domains=$(getDomains "$c"/cert.pem)
-  /root/letsencrypt/letsencrypt-auto --renew certonly -c /etc/letsencrypt/cli.conf --domains=$domains
-done
-service apache2 start
+/root/letsencrypt/letsencrypt-auto renew --pre-hook="service apache2 stop" --post-hook="service apache2 start" \
+    -c /etc/letsencrypt/cli.conf
 
 # Services that rely on LE certificates may need restarted and/or other actions.
 for script in $(find /etc/letsencrypt/postrenew/ -maxdepth 1 -type f -executable); do

--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -24,8 +24,8 @@
 
 - name: Install crontab entry for LetsEncrypt
   copy:
-    src=etc_cron-monthly_letsencrypt-renew
-    dest=/etc/cron.monthly/letsencrypt-renew
+    src=etc_cron-daily_letsencrypt-renew
+    dest=/etc/cron.daily/letsencrypt-renew
     owner=root
     group=root
     mode=0755

--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -19,16 +19,35 @@
   register: le_deps_result
   changed_when: "'Bootstrapping dependencies' in le_deps_result.stdout"
 
+- name: Create directory for pre-renewal scripts
+  file: state=directory path=/etc/letsencrypt/prerenew group=root owner=root
+
 - name: Create directory for post-renewal scripts
   file: state=directory path=/etc/letsencrypt/postrenew group=root owner=root
 
+- name: Create pre-renew hook to stop apache
+  copy:
+    content: "#!/bin/bash\n\nservice apache2 stop\n"
+    dest: /etc/letsencrypt/prerenew/apache
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Create post-renew hook to start apache
+  copy:
+    content: "#!/bin/bash\n\nservice apache2 start\n"
+    dest: /etc/letsencrypt/postrenew/apache
+    owner: root
+    group: root
+    mode: 0755
+
 - name: Install crontab entry for LetsEncrypt
   copy:
-    src=etc_cron-daily_letsencrypt-renew
-    dest=/etc/cron.daily/letsencrypt-renew
-    owner=root
-    group=root
-    mode=0755
+    src: etc_cron-daily_letsencrypt-renew
+    dest: /etc/cron.daily/letsencrypt-renew
+    owner: root
+    group: root
+    mode: 0755
 
 - name: Create live directory for LetsEncrypt cron job
   file: state=directory path=/etc/letsencrypt/live group=root owner=root

--- a/roles/ircbouncer/templates/etc_letsencrypt_postrenew_znc.sh.j2
+++ b/roles/ircbouncer/templates/etc_letsencrypt_postrenew_znc.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Executed by /etc/cron.monthly/letsencrypt-renew
+# Executed by /etc/cron.daily/letsencrypt-renew
 
 cat /etc/letsencrypt/live/{{ domain }}/{privkey,fullchain}.pem > /usr/lib/znc/znc.pem
 chown znc.znc /usr/lib/znc/znc.pem


### PR DESCRIPTION
Unfortunately I made a duplicate of #553. 😞 So for description, please see that PR.

But additionally there are `--pre-hook` and `--post-hook` used for renewal, which ensures apache won't be restarted unless necessary. [This is pretty new in LE client](https://community.letsencrypt.org/t/client-version-0-5-0/13770).

Also I have changed a cron frequency to daily, [as described on LE website](https://letsencrypt.org/getting-started/):

> We recommend running renewal scripts at least daily, at a random hour and minute. This gives the script many days to retry renewal in case of transient network failures or server outages.