### PR TITLE
Use submission port for client outgoing email

### DIFF
--- a/roles/mailserver/files/etc_postfix_master.cf
+++ b/roles/mailserver/files/etc_postfix_master.cf
@@ -13,12 +13,13 @@ smtp       inet  n       -       -       -       1       postscreen
 smtpd      pass  -       -       -       -       -       smtpd
 dnsblog    unix  -       -       -       -       0       dnsblog
 tlsproxy   unix  -       -       -       -       0       tlsproxy
-#submission inet  n       -       -       -       -       smtpd
-#  -o syslog_name=postfix/submission
-#  -o smtpd_tls_security_level=encrypt
-#  -o smtpd_etrn_restrictions=reject
-#  -o smtpd_client_restrictions=permit_sasl_authenticated,reject
-#  -o milter_macro_daemon_name=ORIGINATING
+submission inet  n       -       -       -       -       smtpd
+  -o syslog_name=postfix/submission
+  -o smtpd_tls_security_level=encrypt
+  -o smtpd_etrn_restrictions=reject
+  -o smtpd_client_restrictions=permit_sasl_authenticated,reject_unauth_destination,reject
+  -o smtpd_sasl_security_options=noanonymous,noplaintext
+  -o smtpd_sasl_tls_security_options=noanonymous
 
 # SMTP over SSL/TLS on port 465.
 smtps     inet  n       -       -       -       -       smtpd

--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -63,4 +63,5 @@
   with_items:
     - smtp
     - ssmtp
+    - submission
   tags: ufw

--- a/roles/mailserver/templates/var_www_autoconfig_mail_config-v1.1.j2
+++ b/roles/mailserver/templates/var_www_autoconfig_mail_config-v1.1.j2
@@ -20,8 +20,8 @@
         </incomingServer>
         <outgoingServer type="smtp">
             <hostname>{{ mail_server_hostname }}</hostname>
-            <port>465</port>
-            <socketType>SSL</socketType>
+            <port>587</port>
+            <socketType>STARTTLS</socketType>
             <authentication>password-cleartext</authentication>
             <username>%EMAILADDRESS%</username>
         </outgoingServer>


### PR DESCRIPTION
Currently client email is submitted on port 465.  This has been
deprecated for years.  The correct way to submit email is on the
submission port (587).

This patch makes this change.  The postfix master.cf file is modified to
use the submission port, carrying over relevant configuration from the
smtps port.  Both firewall rules and the email autoconfig file are
updated accordingly.