### PR TITLE
Eliminate need for access_compat module in Apache

### DIFF
--- a/roles/git/templates/etc_apache2_sites-available_cgit.j2
+++ b/roles/git/templates/etc_apache2_sites-available_cgit.j2
@@ -12,8 +12,7 @@
     <Directory "/var/www/htdocs/cgit/">
         AllowOverride None
         Options +ExecCGI
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /cgit.png         /var/www/htdocs/cgit/cgit.png

--- a/roles/monitoring/files/etc_apache2_sites-available_00-status.conf
+++ b/roles/monitoring/files/etc_apache2_sites-available_00-status.conf
@@ -3,8 +3,6 @@
 <VirtualHost *:80>
   <Location />
     SetHandler server-status
-    Order deny,allow
-    Deny from all
-    Allow from 127.0.0.1
+    Require ip 127.0.0.1
   </Location>
 </VirtualHost>

--- a/roles/news/templates/etc_apache2_sites-available_selfoss.j2
+++ b/roles/news/templates/etc_apache2_sites-available_selfoss.j2
@@ -16,8 +16,7 @@
 
     <Directory /var/www/selfoss>
         AllowOverride All
-        Order allow,deny
-        allow from all
+        Require all granted
         DirectoryIndex index.php
     </Directory>
 </VirtualHost>

--- a/roles/readlater/templates/etc_apache2_sites-available_wallabag.j2
+++ b/roles/readlater/templates/etc_apache2_sites-available_wallabag.j2
@@ -16,8 +16,7 @@
 
     <Directory /var/www/wallabag>
         AllowOverride All
-        Order allow,deny
-        allow from all
+        Require all granted
         DirectoryIndex index.php
     </Directory>
 </VirtualHost>


### PR DESCRIPTION
The directives provided by `mod_access_compat` are deprecated.  This
patch eliminates references to them.