### PR TITLE
Remove duplicate when statement in Let's Encrypt task

### DIFF
--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -93,8 +93,7 @@
   shell: cat /etc/letsencrypt/live/{{ domain }}/cert.pem
     /etc/letsencrypt/live/{{ domain }}/chain.pem >
     /etc/letsencrypt/live/{{ domain }}/fullchain.pem
-  when: private_key.changed or certificate.changed or ca_certificate.changed
-  when: ansible_ssh_user == "vagrant"
+  when: (private_key.changed or certificate.changed or ca_certificate.changed) and ansible_ssh_user == "vagrant"
 
 - name: Set permissions on combined SSL public cert
   file: name=/etc/letsencrypt/live/{{ domain }}/fullchain.pem mode=0644


### PR DESCRIPTION
Getting my feet wet with Ansible and trying to get the `jessie` branch working on my server. Saw the following warning and thought is was an easy candidate to find out how to help the project a tiny little bit.

```
TASK [common : include] ********************************************************
 [WARNING]: While constructing a mapping from /Users/me/sovereig/roles/common/tasks/letsencrypt.yml, line 92, column 3, found
a duplicate dict key (when).  Using last defined value only.
```

Using Ansible 2.1.0.0.

The diff should be self explanatory. Someone probably accidentally duplicated the `when` statement when adding the Let's Encrypt test recipes meaning that [line 97](https://github.com/sovereign/sovereign/pull/570/commits/264c232bbfd63ac7f2b1a9f7a843b80fe68d3b66#diff-5edbcf92d4f29eadd38d08e1358f740cL97) is ignored as Ansible only looks at the last `when` statement.

This is a mini insignificant fix and I am new to both Ansible and this project so feel free to close and ignore the pull request. Thank you for building Sovereign.