### PR TITLE
Fix bug exposed by commit 264c232b

### DIFF
--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -71,6 +71,7 @@
   copy: src=wildcard_private.key
     dest=/etc/letsencrypt/live/{{ domain }}/privkey.pem
     owner=root group=ssl-cert mode=0640
+  register: private_key
   when: ansible_ssh_user == "vagrant"
 
 - name: Copy SSL public certificate into place for testing


### PR DESCRIPTION
The `private_key` variable used to check for changes was never
registered.