### PR TITLE
Fix SSH connections to Github

### DIFF
--- a/roles/common/templates/etc_ssh_ssh_config.j2
+++ b/roles/common/templates/etc_ssh_ssh_config.j2
@@ -1,3 +1,8 @@
+# Github needs diffie-hellman-group-exchange-sha1 some of the time but not always.
+Host github.com
+    KexAlgorithms {{ kex_algorithms }},diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1
+
+Host *
     Ciphers {{ ciphers }}
     KexAlgorithms {{ kex_algorithms }}
     SendEnv LANG LC_*


### PR DESCRIPTION
Fixes the *"Unable to negotiate a key exchange method"* error when trying to communicate with Github using SSH. This was caused by setting too restrictive default value for `KexAlgorithms` in SSH config file.

Related links:
- [testing Github SSH connection](https://help.github.com/articles/testing-your-ssh-connection/)
- [article containing a fix](https://stribika.github.io/2015/01/04/secure-secure-shell.html)