### PR TITLE
changed mailserver role to not clobber users/passwords on every run

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+inventory = hosts
+gathering = smart
+host_key_checking = False
+remote_user = deploy
+jinja2_extensions = jinja2.ext.do
+

--- a/roles/mailserver/files/aliascheck.sql
+++ b/roles/mailserver/files/aliascheck.sql
@@ -1,0 +1,2 @@
+-- Generate a list of all our aliases
+SELECT domain_id, source, destination from virtual_aliases;

--- a/roles/mailserver/files/domaincheck.sql
+++ b/roles/mailserver/files/domaincheck.sql
@@ -1,0 +1,2 @@
+-- Generate a list of all our domains
+SELECT name from virtual_domains;

--- a/roles/mailserver/files/usercheck.sql
+++ b/roles/mailserver/files/usercheck.sql
@@ -1,0 +1,2 @@
+-- Generate a list of all our users
+SELECT email from virtual_users;

--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -41,6 +41,28 @@
   postgresql_db: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ mail_db_database }} state=present owner={{ mail_db_username }}
   notify: import sql postfix
 
+- name: Copy sql file to generate current states
+  copy: src={{ item }} dest=/etc/postfix/{{ item }} owner=root group=root mode=0600
+  with_items:
+    - usercheck.sql
+    - domaincheck.sql
+    - aliascheck.sql
+
+- name: Run the user check
+  shell: PGPASSWORD='{{ mail_db_password }}' psql -h localhost -d {{ mail_db_database }} -U {{ mail_db_username }} -f /etc/postfix/usercheck.sql --set ON_ERROR_STOP=1
+  register: mail_users
+  ignore_errors: true
+
+- name: Run the domain check
+  shell: PGPASSWORD='{{ mail_db_password }}' psql -h localhost -d {{ mail_db_database }} -U {{ mail_db_username }} -f /etc/postfix/domaincheck.sql --set ON_ERROR_STOP=1
+  register: mail_domains
+  ignore_errors: true
+
+- name: Run the alias check
+  shell: PGPASSWORD='{{ mail_db_password }}' psql -h localhost -d {{ mail_db_database }} -U {{ mail_db_username }} -f /etc/postfix/aliascheck.sql --set ON_ERROR_STOP=1 | tail -n +3 | head -n -2 | awk '{ print $1 "," $3 "," $5 }'
+  register: mail_aliases
+  ignore_errors: true
+
 - name: Copy import.sql
   template: src=mailserver.sql.j2 dest=/etc/postfix/import.sql owner=root group=root mode=0600
   notify: import sql postfix

--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -41,6 +41,10 @@
   postgresql_db: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ mail_db_database }} state=present owner={{ mail_db_username }}
   notify: import sql postfix
 
+- name: Get Postgres minor version
+  shell: psql --version | grep 9. | awk '{ print $3 }' | awk -F. '{ print $2 }'
+  register: postgres_minor
+
 - name: Copy sql file to generate current states
   copy: src={{ item }} dest=/etc/postfix/{{ item }} owner=root group=root mode=0600
   with_items:

--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -49,7 +49,8 @@
     - aliascheck.sql
 
 - name: Run the user check
-  shell: PGPASSWORD='{{ mail_db_password }}' psql -h localhost -d {{ mail_db_database }} -U {{ mail_db_username }} -f /etc/postfix/usercheck.sql --set ON_ERROR_STOP=1
+  shell: PGPASSWORD='{{ mail_db_password }}' psql -h localhost -d {{ mail_db_database }} -U {{ mail_db_username }} -f /etc/postfix/usercheck.sql --set ON_ERROR_STOP=1 | tail -n +3 | head -n -2 | awk '{ print $1 }'
+
   register: mail_users
   ignore_errors: true
 

--- a/roles/mailserver/templates/mailserver.sql.j2
+++ b/roles/mailserver/templates/mailserver.sql.j2
@@ -17,11 +17,39 @@ CREATE TABLE IF NOT EXISTS "virtual_users" (
 CREATE TABLE IF NOT EXISTS "virtual_aliases" (
         "id" SERIAL,
         "domain_id" int NOT NULL,
-        "source" TEXT NOT NULL UNIQUE,
+        "source" TEXT NOT NULL,
         "destination" TEXT NOT NULL,
         PRIMARY KEY ("id"),
         FOREIGN KEY (domain_id) REFERENCES virtual_domains(id) ON DELETE CASCADE
 );
+
+{# this entire block is from [here](http://dba.stackexchange.com/questions/35616/create-index-if-it-does-not-exist) #}
+{% if postgres_minor.stdout|int <= 3 %}
+{# 9.3 and lower #}
+DO $$
+BEGIN
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'source_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+    CREATE INDEX source_idx ON public.virtual_aliases (source);
+END IF;
+
+END$$;
+{% elif postgres_minor.stdout|int == 4 %}
+IF NOT EXISTS (
+  SELECT to_regclass('public.source_idx');
+  ) THEN
+  CREATE INDEX source_idx ON public.virtual_aliases (source);
+{% elif postgres_minor.stdout|int > 4 %}
+CREATE INDEX IF NOT EXISTS source_idx ON public.virtual_aliases (source);
+{% endif %}
+
 
 {# set a place to capture deleted domains #}
 {% set deleted_domains = [] %}
@@ -115,7 +143,7 @@ INSERT INTO "virtual_aliases" ("domain_id", "source", "destination")
 (not virtual_alias.active|default(True) or
 source_domain in deleted_domains or
 dest_domain in deleted_domains) or
-virtual_alias.destination not in mail_users.stdout_lines %}
+virtual_alias.destination in deleted_users %}
 {# inactive alias or domains deleted, but is in database - remove it #}
 DELETE FROM "virtual_aliases" WHERE
     domain_id = '{{ virtual_alias.domain_pk_id }}' AND

--- a/roles/mailserver/templates/mailserver.sql.j2
+++ b/roles/mailserver/templates/mailserver.sql.j2
@@ -1,16 +1,9 @@
--- If tables are not dropped, have to truncate before insert or use "insert or replace" (not postgres compatible)
-
-DROP TABLE IF EXISTS "virtual_users";
-DROP TABLE IF EXISTS "virtual_aliases";
-DROP TABLE IF EXISTS "virtual_domains";
 
 CREATE TABLE IF NOT EXISTS "virtual_domains" (
         "id" SERIAL,
-        "name" TEXT NOT NULL,
+        "name" TEXT NOT NULL UNIQUE,
         PRIMARY KEY ("id")
 );
-
-CREATE UNIQUE INDEX name_idx ON virtual_domains (name);
 
 CREATE TABLE IF NOT EXISTS "virtual_users" (
         "id" SERIAL,
@@ -21,37 +14,88 @@ CREATE TABLE IF NOT EXISTS "virtual_users" (
         FOREIGN KEY (domain_id) REFERENCES virtual_domains(id) ON DELETE CASCADE
 );
 
-
-CREATE UNIQUE INDEX email_idx ON virtual_users (email);
-
 CREATE TABLE IF NOT EXISTS "virtual_aliases" (
         "id" SERIAL,
         "domain_id" int NOT NULL,
-        "source" TEXT NOT NULL,
+        "source" TEXT NOT NULL UNIQUE,
         "destination" TEXT NOT NULL,
         PRIMARY KEY ("id"),
         FOREIGN KEY (domain_id) REFERENCES virtual_domains(id) ON DELETE CASCADE
 );
 
-CREATE INDEX source_idx ON virtual_aliases (source);
+{# set a place to capture deleted domains #}
+{% set deleted_domains = [] %}
+
+{# set a place to capture active domains #}
+{% set active_domains = [] %}
 
 {% for virtual_domain in mail_virtual_domains %}
+{% if virtual_domain.active|default(True) %}
+{# we need to track all active domains to avoid inserting
+   aliases below for domains that we aren't adding #}
+{% do active_domains.append(virtual_domain.pk_id) %}
+{% endif %}
+{% if mail_domains.stdout.find(virtual_domain.name) == -1 and
+virtual_domain.active|default(True) %}
+{# active domain, not in database - add it #}
 INSERT INTO "virtual_domains" ("id", "name")
         VALUES ('{{ virtual_domain.pk_id }}', '{{ virtual_domain.name }}');
+
+{% elif mail_domains.stdout.find(virtual_domain.name) != -1 and
+not virtual_domain.active|default(True) %}
+{# inactive domain, in database - remove it #}
+DELETE FROM "virtual_domains" WHERE
+  id = '{{ virtual_domain.pk_id }}' AND
+  name = '{{ virtual_domain.name }}';
+
+{# add our domain to the list for later checking #}
+{% do deleted_domains.append(virtual_domain.name) %}
+{% endif %}
 {% endfor %}
 
 {% for virtual_user in mail_virtual_users %}
+{% if mail_users.stdout.find(virtual_user.account + '@' + virtual_user.domain) == -1 and
+virtual_user.active|default(True) and
+virtual_user.domain not in deleted_domains and
+virtual_user.domain_pk_id in active_domains %}
+{# Active user, not in database - add it #}
 INSERT INTO "virtual_users"  ("domain_id", "password" , "email")
 	VALUES (
 		'{{ virtual_user.domain_pk_id }}',
 		'{{ virtual_user.password_hash }}',
 		'{{ virtual_user.account }}@{{ virtual_user.domain }}'
 	);
+{% elif mail_users.stdout.find(virtual_user.account + '@' + virtual_user.domain) != -1 and
+not virtual_user.active|default(True) %}
+{# inactive user, in database - remove it #}
+DELETE FROM "virtual_users" WHERE
+    domain_id = '{{ virtual_user.domain_pk_id }}' AND
+    email = '{{ virtual_user.account }}@{{ virtual_user.domain }}';
+{% endif %}
 {% endfor %}
 
 {% if mail_virtual_aliases is defined %}
 {% for virtual_alias in mail_virtual_aliases %}
+{% set source_name,source_domain = virtual_alias.source.split('@') %}
+{% set dest_name,dest_domain = virtual_alias.destination.split('@') %}
+{% set search_string = [virtual_alias.domain_pk_id, virtual_alias.source, virtual_alias.destination]|join(',') %}
+{% if mail_aliases.stdout.find(search_string) == -1 and
+virtual_alias.active|default(True) and
+source_domain not in deleted_domains and
+dest_domain not in deleted_domains and
+virtual_alias.domain_pk_id in active_domains %}
+{# active alias, active domains, not in database - add it #}
 INSERT INTO "virtual_aliases" ("domain_id", "source", "destination")
     VALUES ('{{ virtual_alias.domain_pk_id }}', '{{ virtual_alias.source }}', '{{virtual_alias.destination }}');
+{% elif mail_aliases.stdout.find(search_string) != -1 and
+(not virtual_alias.active|default(True) or
+source_domain in deleted_domains or
+dest_domain in deleted_domains) %}
+{# inactive alias or domains deleted, but is in database - remove it #}
+DELETE FROM "virtual_aliases" WHERE
+    domain_id = '{{ virtual_alias.domain_pk_id }}' AND
+    source = '{{ virtual_alias.source }}' AND
+    destination = '{{ virtual_alias.destination }}';
+{% endif %}
 {% endfor %}
 {% endif %}

--- a/roles/mailserver/templates/mailserver.sql.j2
+++ b/roles/mailserver/templates/mailserver.sql.j2
@@ -92,6 +92,8 @@ DELETE FROM "virtual_users" WHERE
 {% if email not in active_users and email not in deleted_users %}
 DELETE FROM "virtual_users" WHERE
     email = '{{ email }}';
+{# remove the email to indicate that we deleted this user - used for aliases below #}
+{% do mail_users.stdout_lines.remove(email) %}
 {% endif %}
 {% endfor %}
 
@@ -104,14 +106,16 @@ DELETE FROM "virtual_users" WHERE
 virtual_alias.active|default(True) and
 source_domain not in deleted_domains and
 dest_domain not in deleted_domains and
-virtual_alias.domain_pk_id in active_domains %}
+virtual_alias.domain_pk_id in active_domains and
+virtual_alias.destination in mail_users.stdout_lines %}
 {# active alias, active domains, not in database - add it #}
 INSERT INTO "virtual_aliases" ("domain_id", "source", "destination")
     VALUES ('{{ virtual_alias.domain_pk_id }}', '{{ virtual_alias.source }}', '{{virtual_alias.destination }}');
 {% elif mail_aliases.stdout.find(search_string) != -1 and
 (not virtual_alias.active|default(True) or
 source_domain in deleted_domains or
-dest_domain in deleted_domains) %}
+dest_domain in deleted_domains) or
+virtual_alias.destination not in mail_users.stdout_lines %}
 {# inactive alias or domains deleted, but is in database - remove it #}
 DELETE FROM "virtual_aliases" WHERE
     domain_id = '{{ virtual_alias.domain_pk_id }}' AND

--- a/roles/mailserver/templates/mailserver.sql.j2
+++ b/roles/mailserver/templates/mailserver.sql.j2
@@ -53,7 +53,15 @@ DELETE FROM "virtual_domains" WHERE
 {% endif %}
 {% endfor %}
 
+{# set up a place to store deleted users #}
+{% set deleted_users = [] %}
+
+{# set up a place to store active users #}
+{% set active_users = [] %}
+
 {% for virtual_user in mail_virtual_users %}
+{# store this user for later checking #}
+{% do active_users.append(virtual_user.account + '@' + virtual_user.domain) %}
 {% if mail_users.stdout.find(virtual_user.account + '@' + virtual_user.domain) == -1 and
 virtual_user.active|default(True) and
 virtual_user.domain not in deleted_domains and
@@ -65,12 +73,25 @@ INSERT INTO "virtual_users"  ("domain_id", "password" , "email")
 		'{{ virtual_user.password_hash }}',
 		'{{ virtual_user.account }}@{{ virtual_user.domain }}'
 	);
+
 {% elif mail_users.stdout.find(virtual_user.account + '@' + virtual_user.domain) != -1 and
 not virtual_user.active|default(True) %}
 {# inactive user, in database - remove it #}
 DELETE FROM "virtual_users" WHERE
     domain_id = '{{ virtual_user.domain_pk_id }}' AND
     email = '{{ virtual_user.account }}@{{ virtual_user.domain }}';
+
+{# store this user for later checking #}
+{% do deleted_users.append(virtual_user.account + '@' + virtual_user.domain) %}
+
+{% endif %}
+{% endfor %}
+
+{# do the check in reverse - delete anything that is in the db and not in config #}
+{% for email in mail_users.stdout_lines %}
+{% if email not in active_users and email not in deleted_users %}
+DELETE FROM "virtual_users" WHERE
+    email = '{{ email }}';
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Sovereign, as written, drops all tables and recreates them on every run. In doing so it recreates all users with passwords as originally set. There is no provision to allow users to change their own passwords (though I'm about to work on that), and if they did, the passwords would be clobbered on the next run. This also creates a race condition - email that arrives during the instant that the database is down will be dropped or misrouted.

This PR changes that. It adds some additional plays to determine what users and domains exist and modifies the template to not add those that do. It also adds an option for `active: False` for each object (domain, user, alias), which will remove it from the database if it exists. Domains are sent through two tests - they must be in a list of domains that exist in the database, and they must not have been deleted during this run. Users and aliases are only added for domains that pass both tests. Finally, in order to keep the `CREATE TABLE IF NOT EXISTS` logic, the three indices were moved to the table create blocks.

The result is that `import.sql` will have only the statements necessary to create the tables and add/remove objects that _need_ to be added or removed. Users or aliases left behind for deleted domains are ignored. Nothing is dropped, so once users have the ability to change their passwords, the integrity of those passwords is preserved, and I, as the admin, do not know what they are. This final point is very important for trust.

This PR is applied against your current master branch, so it is not dependent on anything I've already submitted. I had to provide `ansible.cfg` in order to enable the Jinja `do` extension, so I tossed in some other harmless configuration options that make for nicer command-lines at runtime.