### PR TITLE
make letsencrypt output silent (only output on error)

### DIFF
--- a/roles/common/files/etc_cron-daily_letsencrypt-renew
+++ b/roles/common/files/etc_cron-daily_letsencrypt-renew
@@ -3,6 +3,6 @@ set -o errexit
 # Renew all live certificates with LetsEncrypt.  This needs to run at least
 # once every three months, but recommended frequency is once a day.
 
-/root/letsencrypt/letsencrypt-auto renew -c /etc/letsencrypt/cli.conf \
+/root/letsencrypt/letsencrypt-auto renew -q -c /etc/letsencrypt/cli.conf \
 --pre-hook="find /etc/letsencrypt/prerenew/ -maxdepth 1 -type f -executable -exec {} \;" \
 --post-hook="find /etc/letsencrypt/postrenew/ -maxdepth 1 -type f -executable -exec {} \;"


### PR DESCRIPTION
Automatic renewal of certificates should occur silently if there was no error, currently a daily reminder is sent by mail that nothing happened.
This is also the [official recommendation](https://certbot.eff.org/docs/using.html#renewal):
>If you’re sure that this command executes successfully without human intervention, you can add the command to crontab (since certificates are only renewed when they’re determined to be near expiry, the command can run on a regular basis, like every week or every day). **In that case, you are likely to want to use the -q or --quiet quiet flag to silence all output except errors.**