### PR TITLE
Roundcube from source

### DIFF
--- a/filter_plugins/core.py
+++ b/filter_plugins/core.py
@@ -1,0 +1,8 @@
+def wrap(list):
+    return [ '"' + x + '"' for x in list]
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'wrap': wrap
+        }

--- a/roles/webmail/files/roundcube_plugins_managesieve_config.inc.php
+++ b/roles/webmail/files/roundcube_plugins_managesieve_config.inc.php
@@ -1,0 +1,100 @@
+<?php
+
+// managesieve server port. When empty the port will be determined automatically
+// using getservbyname() function, with 4190 as a fallback.
+$config['managesieve_port'] = null;
+
+// managesieve server address, default is localhost.
+// Replacement variables supported in host name:
+// %h - user's IMAP hostname
+// %n - http hostname ($_SERVER['SERVER_NAME'])
+// %d - domain (http hostname without the first part)
+// For example %n = mail.domain.tld, %d = domain.tld
+$config['managesieve_host'] = 'localhost';
+
+// authentication method. Can be CRAM-MD5, DIGEST-MD5, PLAIN, LOGIN, EXTERNAL
+// or none. Optional, defaults to best method supported by server.
+$config['managesieve_auth_type'] = null;
+
+// Optional managesieve authentication identifier to be used as authorization proxy.
+// Authenticate as a different user but act on behalf of the logged in user.
+// Works with PLAIN and DIGEST-MD5 auth.
+$config['managesieve_auth_cid'] = null;
+
+// Optional managesieve authentication password to be used for imap_auth_cid
+$config['managesieve_auth_pw'] = null;
+
+// use or not TLS for managesieve server connection
+// Note: tls:// prefix in managesieve_host is also supported
+$config['managesieve_usetls'] = false;
+
+// Connection scket context options
+// See http://php.net/manual/en/context.ssl.php
+// The example below enables server certificate validation
+//$config['managesieve_conn_options'] = array(
+//  'ssl'         => array(
+//     'verify_peer'  => true,
+//     'verify_depth' => 3,
+//     'cafile'       => '/etc/openssl/certs/ca.crt',
+//   ),
+// );
+$config['managesieve_conn_options'] = null;
+
+// default contents of filters script (eg. default spam filter)
+$config['managesieve_default'] = '/var/lib/roundcube/config/global.sieve';
+
+// The name of the script which will be used when there's no user script
+$config['managesieve_script_name'] = 'roundcube';
+
+// Sieve RFC says that we should use UTF-8 endcoding for mailbox names,
+// but some implementations does not covert UTF-8 to modified UTF-7.
+// Defaults to UTF7-IMAP
+$config['managesieve_mbox_encoding'] = 'UTF-8';
+
+// I need this because my dovecot (with listescape plugin) uses
+// ':' delimiter, but creates folders with dot delimiter
+$config['managesieve_replace_delimiter'] = '';
+
+// disabled sieve extensions (body, copy, date, editheader, encoded-character,
+// envelope, environment, ereject, fileinto, ihave, imap4flags, index,
+// mailbox, mboxmetadata, regex, reject, relational, servermetadata,
+// spamtest, spamtestplus, subaddress, vacation, variables, virustest, etc.
+// Note: not all extensions are implemented
+$config['managesieve_disabled_extensions'] = array();
+
+// Enables debugging of conversation with sieve server. Logs it into <log_dir>/sieve
+$config['managesieve_debug'] = false;
+
+// Enables features described in http://wiki.kolab.org/KEP:14
+$config['managesieve_kolab_master'] = false;
+
+// Script name extension used for scripts including. Dovecot uses '.sieve',
+// Cyrus uses '.siv'. Doesn't matter if you have managesieve_kolab_master disabled.
+$config['managesieve_filename_extension'] = '.sieve';
+
+// List of reserved script names (without extension).
+// Scripts listed here will be not presented to the user.
+$config['managesieve_filename_exceptions'] = array();
+
+// List of domains limiting destination emails in redirect action
+// If not empty, user will need to select domain from a list
+$config['managesieve_domains'] = array();
+
+// Enables separate management interface for vacation responses (out-of-office)
+// 0 - no separate section (default),
+// 1 - add Vacation section,
+// 2 - add Vacation section, but hide Filters section
+$config['managesieve_vacation'] = 0;
+
+// Default vacation interval (in days).
+// Note: If server supports vacation-seconds extension it is possible
+// to define interval in seconds here (as a string), e.g. "3600s".
+$config['managesieve_vacation_interval'] = 0;
+
+// Some servers require vacation :addresses to be filled with all
+// user addresses (aliases). This option enables automatic filling
+// of these on initial vacation form creation.
+$config['managesieve_vacation_addresses_init'] = false;
+
+// Supported methods of notify extension. Default: 'mailto'
+$config['managesieve_notify_methods'] = array('mailto');

--- a/roles/webmail/files/update_passwd.sql
+++ b/roles/webmail/files/update_passwd.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION update_passwd(hash text, account text) RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    res integer;
+BEGIN
+    UPDATE virtual_users SET password = hash WHERE email = account RETURNING id INTO res;
+    RETURN res;
+END;
+$$;

--- a/roles/webmail/tasks/roundcube_source.yml
+++ b/roles/webmail/tasks/roundcube_source.yml
@@ -8,6 +8,21 @@
     - php5-pgsql
     - php5-pspell
 
+- name: Uninstall Roundcube packages
+  apt: pkg={{ item }} state=absent
+  with_items:
+    - roundcube
+    - roundcube-pgsql
+    - roundcube-plugins
+
+- name: determine if /var/lib/roundcube stayed behind
+  command: test -d /var/lib/roundcube
+  register: roundcube_dir_exists
+
+- name: Clean up krufty /var/lib/roundcube so we can symlink it
+  file: path=/var/lib/roundcube state=absent
+  when: roundcube_dir_exists|success
+
 - name: fetch roundcube source
   shell: curl -OL https://github.com/roundcube/roundcubemail/releases/download/{{ roundcube_version }}/roundcubemail-{{ roundcube_version }}-complete.tar.gz
          chdir=/root

--- a/roles/webmail/tasks/roundcube_source.yml
+++ b/roles/webmail/tasks/roundcube_source.yml
@@ -1,0 +1,114 @@
+---
+- name: install roundcube dependencies
+  apt: pkg={{ item }} state=latest
+  with_items:
+    - aspell
+    - php5-gd
+    - php5-mcrypt
+    - php5-pgsql
+    - php5-pspell
+
+- name: fetch roundcube source
+  shell: curl -OL https://github.com/roundcube/roundcubemail/releases/download/{{ roundcube_version }}/roundcubemail-{{ roundcube_version }}-complete.tar.gz
+         chdir=/root
+         creates=roundcubemail-{{ roundcube_version }}-complete.tar.gz
+
+- name: extract roundcube source to web root
+  unarchive: src=/root/roundcubemail-{{ roundcube_version }}-complete.tar.gz
+             dest=/var/lib/
+             copy=no
+             creates=/var/lib/roundcubemail-{{ roundcube_version }}/robots.txt
+  when: ansible_distribution_release == 'trusty'
+
+- name: Create symlink to roundcube content
+  file: src=/var/lib/roundcubemail-{{ roundcube_version }} dest=/var/lib/roundcube state=link
+
+- name: set permissions on web-writable directories
+  file: path=/var/lib/roundcube/{{ item }} owner=www-data group=www-data mode=0755 recurse=true
+  with_items:
+    - temp
+    - logs
+
+- name: create roundcube database user
+  postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ webmail_db_username }} password="{{ webmail_db_password }}" state=present
+
+- name: Create database for roundcube
+  postgresql_db: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ webmail_db_database }} state=present owner={{ webmail_db_username }}
+
+- name: copy roundcube db initialization file
+  template: src=roundcube_postgres_initial.sql.j2 dest=/var/lib/roundcube/SQL/postgres.initial.sql owner={{ db_admin_username }} group=www-data mode=0640 force=yes
+  notify: init roundcube database
+
+- name: pause to init database
+  meta: flush_handlers
+
+- name: copy roundcube skins source files
+  copy: src=roundcube_plus_skin_{{ item }}.tar.gz dest=/var/tmp force=yes
+  with_items: "{{ roundcube_skins|default([]) }}"
+  register: skins
+
+- name: extract roundcube skins if we copied them
+  unarchive: src=/var/tmp/roundcube_plus_skin_{{ item.item }}.tar.gz dest=/var/lib/roundcube/ copy=no
+  when: item|changed
+  with_items: "{{ skins.results }}"
+
+- name: extract roundcube skins if they're missing
+  unarchive: src=/var/tmp/roundcube_plus_skin_{{ item }}.tar.gz dest=/var/lib/roundcube/ copy=no creates=/var/lib/roundcube/skins/{{ item }}
+  when: not skins|changed
+  with_items: "{{ roundcube_skins|default([]) }}"
+
+- name: remove extra skins files from roundcube directory
+  file: dest=/var/lib/roundcube/{{ item }} state=absent
+  with_items:
+    - README
+    - VERSIONS
+
+- name: Download carddav plugin release
+  command: wget https://github.com/blind-coder/rcmcarddav/archive/carddav_{{ carddav_version }}.tar.gz chdir=/root creates=carddav_{{ carddav_version }}.tar.gz
+
+- name: Decompress carddav plugin source
+  unarchive: src=/root/carddav_{{ carddav_version }}.tar.gz
+             dest=/root copy=no
+             creates=/root/rcmcarddav-carddav_{{ carddav_version }}
+
+- name: Move carddav plugin files to /var/lib/roundcube/plugins/carddav
+  command: mv rcmcarddav-carddav_{{ carddav_version }} /var/lib/roundcube/plugins/carddav chdir=/root creates=/var/lib/roundcube/plugins/carddav
+
+- name: Download Google Authenticator roundcube plugin
+  git: repo=https://github.com/alexandregz/twofactor_gauthenticator.git
+       dest=/var/lib/roundcube/plugins/twofactor_gauthenticator
+       accept_hostkey=yes
+       version=master
+
+- name: Install password plugin configuration
+  template: src=roundcube_password_config.inc.php.j2 dest=/var/lib/roundcube/plugins/password/config.inc.php group=www-data mode=0640 force=yes
+
+- name: Install sql password function
+  copy: src=update_passwd.sql dest=/etc/postfix/update_passwd.sql owner=root group=root mode=0644
+  notify: install passwd function
+
+- name: Configure the Apache HTTP server for roundcube
+  template: src=roundcube_source.conf.j2 dest=/etc/apache2/sites-available/roundcube.conf group=root owner=root force=yes
+  notify: restart apache
+
+- name: Enable php5-mcrypt
+  file: src=/etc/php5/mods-available/mcrypt.ini dest=/etc/php5/apache2/conf.d/20-mcrypt.ini owner=root group=root state=link
+
+- name: Configure roundcube (files)
+  copy: src={{ item.src }} dest={{ item.dest }} group=www-data owner=root mode=0640 force=yes
+  with_items:
+    - { src: 'etc_roundcube_global.sieve',                                          dest: '/var/lib/roundcube/config/global.sieve' }
+    - { src: 'usr_share_roundcube_plugins_carddav_config.inc.php',                  dest: '/var/lib/roundcube/plugins/carddav/config.inc.php' }
+    - { src: 'roundcube_plugins_managesieve_config.inc.php',                        dest: '/var/lib/roundcube/plugins/managesieve/config.inc.php' }
+    - { src: 'usr_share_roundcube_plugins_twofactor_gauthenticator_config.inc.php', dest: '/var/lib/roundcube/plugins/twofactor_gauthenticator/config.inc.php' }
+  notify:
+    - import sql carddav
+
+- name: Configure roundcube (templates)
+  template: src={{ item.src }}.j2 dest={{ item.dest }} group=www-data owner=root mode=0640 force=yes
+  with_items:
+    - { src: 'roundcube_config.inc.php',                                          dest: '/var/lib/roundcube/config/config.inc.php' }
+
+- name: Enable roundcube site
+  command: a2ensite roundcube.conf creates=/etc/apache2/sites-enabled/roundcube.conf
+  notify: restart apache

--- a/roles/webmail/templates/roundcube_config.inc.php.j2
+++ b/roles/webmail/templates/roundcube_config.inc.php.j2
@@ -1,0 +1,92 @@
+<?php
+
+/* Local configuration for Roundcube Webmail */
+
+// ----------------------------------
+// SQL DATABASE
+// ----------------------------------
+// Database connection string (DSN) for read+write operations
+// Format (compatible with PEAR MDB2): db_provider://user:password@host/database
+// Currently supported db_providers: mysql, pgsql, sqlite, mssql, sqlsrv, oracle
+// For examples see http://pear.php.net/manual/en/package.database.mdb2.intro-dsn.php
+// NOTE: for SQLite use absolute path (Linux): 'sqlite:////full/path/to/sqlite.db?mode=0646'
+//       or (Windows): 'sqlite:///C:/full/path/to/sqlite.db'
+$config['db_dsnw'] = 'pgsql://{{ webmail_db_username }}:{{ webmail_db_password }}@localhost/{{ webmail_db_database }}';
+
+// ----------------------------------
+// IMAP
+// ----------------------------------
+// The mail host chosen to perform the log-in.
+// Leave blank to show a textbox at login, give a list of hosts
+// to display a pulldown menu or set one host as string.
+// To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://
+// Supported replacement variables:
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
+// %s - domain name after the '@' from e-mail address provided at login screen
+// For example %n = mail.domain.tld, %t = domain.tld
+// WARNING: After hostname change update of mail_host column in users table is
+//          required to match old user data records with the new host.
+$config['default_host'] = 'ssl://127.0.0.1:993';
+
+// ----------------------------------
+// SMTP
+// ----------------------------------
+// SMTP server host (for sending mails).
+// To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://
+// If left blank, the PHP mail() function is used
+// Supported replacement variables:
+// %h - user's IMAP hostname
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
+// %z - IMAP domain (IMAP hostname without the first part)
+// For example %n = mail.domain.tld, %t = domain.tld
+$config['smtp_server'] = 'ssl://127.0.0.1';
+
+// SMTP port (default is 25; use 587 for STARTTLS or 465 for the
+// deprecated SSL over SMTP (aka SMTPS))
+$config['smtp_port'] = 465;
+$config['smtp_user'] = '%u';
+$config['smtp_pass'] = '%p';
+
+// provide an URL where a user can get support for this Roundcube installation
+// PLEASE DO NOT LINK TO THE ROUNDCUBE.NET WEBSITE HERE!
+$config['support_url'] = 'mailto:{{ admin_email }}';
+
+// use this folder to store log files
+// must be writeable for the user who runs PHP process (Apache user if mod_php is being used)
+// This is used by the 'file' log driver.
+$config['log_dir'] = '/var/lib/roundcube/logs/';
+
+// use this folder to store temp files
+// must be writeable for the user who runs PHP process (Apache user if mod_php is being used)
+$config['temp_dir'] = '/var/lib/roundcube/temp/';
+
+// This key is used for encrypting purposes, like storing of imap password
+// in the session. For historical reasons it's called DES_key, but it's used
+// with any configured cipher_method (see below).
+$config['des_key'] = 'sEcZ1Q7SVGr37vp9VRVJmeCG';
+
+// Name your service. This is displayed on the login screen and in the window title
+$config['product_name'] = 'Webmail';
+
+// ----------------------------------
+// PLUGINS
+// ----------------------------------
+// List of active plugins (in plugins/ directory)
+$config['plugins'] = array({{ roundcube_plugins|wrap|join(', ')}}{{', "xskin"' if roundcube_skins|default([]) else ''}});
+
+// Set the spell checking engine. Possible values:
+// - 'googie'  - the default (also used for connecting to Nox Spell Server, see 'spellcheck_uri' setting)
+// - 'pspell'  - requires the PHP Pspell module and aspell installed
+// - 'enchant' - requires the PHP Enchant module
+// - 'atd'     - install your own After the Deadline server or check with the people at http://www.afterthedeadline.com before using their API
+// Since Google shut down their public spell checking service, the default settings
+// connect to http://spell.roundcube.net which is a hosted service provided by Roundcube.
+// You can connect to any other googie-compliant service by setting 'spellcheck_uri' accordingly.
+$config['spellcheck_engine'] = 'pspell';
+
+$config['skin'] = '{{ roundcube_default_skin|default('larry') }}';
+

--- a/roles/webmail/templates/roundcube_password_config.inc.php.j2
+++ b/roles/webmail/templates/roundcube_password_config.inc.php.j2
@@ -1,0 +1,435 @@
+<?php
+
+// {{ ansible_managed }}
+// This config file is used with roundcube 1.2
+
+// Password Plugin options
+// -----------------------
+// A driver to use for password change. Default: "sql".
+// See README file for list of supported driver names.
+$config['password_driver'] = 'sql';
+
+// Determine whether current password is required to change password.
+// Default: false.
+$config['password_confirm_current'] = true;
+
+// Require the new password to be a certain length.
+// set to blank to allow passwords of any length
+$config['password_minimum_length'] = 8;
+
+// Require the new password to contain a letter and punctuation character
+// Change to false to remove this check.
+$config['password_require_nonalpha'] = true;
+
+// Enables logging of password changes into logs/password
+$config['password_log'] = false;
+
+// Comma-separated list of login exceptions for which password change
+// will be not available (no Password tab in Settings)
+$config['password_login_exceptions'] = null;
+
+// Array of hosts that support password changing. Default is NULL.
+// Listed hosts will feature a Password option in Settings; others will not.
+// Example: array('mail.example.com', 'mail2.example.org');
+$config['password_hosts'] = null;
+
+// Enables saving the new password even if it matches the old password. Useful
+// for upgrading the stored passwords after the encryption scheme has changed.
+$config['password_force_save'] = false;
+
+// Enables forcing new users to change their password at their first login.
+$config['password_force_new_user'] = false;
+
+// Default password hashing/crypting algorithm.
+// Possible options: des-crypt, ext-des-crypt, md5-crypt, blowfish-crypt,
+// sha256-crypt, sha512-crypt, md5, sha, smd5, ssha, samba, ad, dovecot, clear.
+// For details see password::hash_password() method.
+$config['password_algorithm'] = 'sha512-crypt';
+
+// Password prefix (e.g. {CRYPT}, {SHA}) for passwords generated
+// using password_algorithm above. Default: empty.
+$config['password_algorithm_prefix'] = '{SHA512-CRYPT}';
+
+// Path for dovecotpw/doveadm-pw (if not in the $PATH).
+// Used for password_algorithm = 'dovecot'.
+ $config['password_dovecotpw'] = '/usr/bin/doveadm pw'; // for dovecot-2.x
+// $config['password_dovecotpw'] = '/usr/local/sbin/dovecotpw'; // for dovecot-1.x
+
+// Dovecot password scheme.
+// Used for password_algorithm = 'dovecot'.
+$config['password_dovecotpw_method'] = 'CRAM-MD5';
+
+// Iteration count parameter for Blowfish-based hashing algo.
+// It must be between 4 and 31. Default: 12.
+// Be aware, the higher the value, the longer it takes to generate the password hashes.
+$config['password_blowfish_cost'] = 12;
+
+// Number of rounds for the sha256 and sha512 crypt hashing algorithms.
+// Must be at least 1000. If not set, then the number of rounds is left up
+// to the crypt() implementation. On glibc this defaults to 5000.
+// Be aware, the higher the value, the longer it takes to generate the password hashes.
+//$config['password_crypt_rounds'] = 50000;
+
+// This option temporarily disables the password change functionality.
+// Use it when the users database server is in maintenance mode or sth like that.
+// You can set it to TRUE/FALSE or a text describing the reason
+// which will replace the default.
+$config['password_disabled'] = false;
+
+
+// SQL Driver options
+// ------------------
+// PEAR database DSN for performing the query. By default
+// Roundcube DB settings are used.
+$config['password_db_dsn'] = 'pgsql://{{mail_db_username}}:{{mail_db_password}}@localhost/{{mail_db_database}}';
+
+// The SQL query used to change the password.
+// The query can contain the following macros that will be expanded as follows:
+//      %p is replaced with the plaintext new password
+//      %P is replaced with the crypted/hashed new password
+//         according to configured password_method
+//      %o is replaced with the old (current) password
+//      %O is replaced with the crypted/hashed old (current) password
+//         according to configured password_method
+//      %h is replaced with the imap host (from the session info)
+//      %u is replaced with the username (from the session info)
+//      %l is replaced with the local part of the username
+//         (in case the username is an email address)
+//      %d is replaced with the domain part of the username
+//         (in case the username is an email address)
+// Deprecated macros:
+//      %c is replaced with the crypt version of the new password, MD5 if available
+//         otherwise DES. More hash function can be enabled using the password_crypt_hash
+//         configuration parameter.
+//      %D is replaced with the dovecotpw-crypted version of the new password
+//      %n is replaced with the hashed version of the new password
+//      %q is replaced with the hashed password before the change
+// Escaping of macros is handled by this module.
+// Default: "SELECT update_passwd(%c, %u)"
+$config['password_query'] = 'SELECT update_passwd(%P, %u)';
+
+// By default the crypt() function which is used to create the %c
+// parameter uses the md5 algorithm (deprecated, use %P).
+// You can choose between: des, md5, blowfish, sha256, sha512.
+$config['password_crypt_hash'] = 'sha512';
+
+// By default domains in variables are using unicode.
+// Enable this option to use punycoded names
+$config['password_idn_ascii'] = false;
+
+// Enables use of password with crypt method prefix in %D, e.g. {MD5}$1$LUiMYWqx$fEkg/ggr/L6Mb2X7be4i1/
+// when using the %D macro (deprecated, use %P)
+$config['password_dovecotpw_with_method'] = false;
+
+// Using a password hash for %n and %q variables (deprecated, use %P).
+// Determine which hashing algorithm should be used to generate
+// the hashed new and current password for using them within the
+// SQL query. Requires PHP's 'hash' extension.
+$config['password_hash_algorithm'] = 'sha1';
+
+// You can also decide whether the hash should be provided
+// as hex string or in base64 encoded format.
+$config['password_hash_base64'] = false;
+
+
+// Poppassd Driver options
+// -----------------------
+// The host which changes the password
+$config['password_pop_host'] = 'localhost';
+
+// TCP port used for poppassd connections
+$config['password_pop_port'] = 106;
+
+
+// SASL Driver options
+// -------------------
+// Additional arguments for the saslpasswd2 call
+$config['password_saslpasswd_args'] = '';
+
+
+// LDAP and LDAP_SIMPLE Driver options
+// -----------------------------------
+// LDAP server name to connect to.
+// You can provide one or several hosts in an array in which case the hosts are tried from left to right.
+// Exemple: array('ldap1.exemple.com', 'ldap2.exemple.com');
+// Default: 'localhost'
+$config['password_ldap_host'] = 'localhost';
+
+// LDAP server port to connect to
+// Default: '389'
+$config['password_ldap_port'] = '389';
+
+// TLS is started after connecting
+// Using TLS for password modification is recommanded.
+// Default: false
+$config['password_ldap_starttls'] = false;
+
+// LDAP version
+// Default: '3'
+$config['password_ldap_version'] = '3';
+
+// LDAP base name (root directory)
+// Exemple: 'dc=exemple,dc=com'
+$config['password_ldap_basedn'] = 'dc=exemple,dc=com';
+
+// LDAP connection method
+// There is two connection method for changing a user's LDAP password.
+// 'user': use user credential (recommanded, require password_confirm_current=true)
+// 'admin': use admin credential (this mode require password_ldap_adminDN and password_ldap_adminPW)
+// Default: 'user'
+$config['password_ldap_method'] = 'user';
+
+// LDAP Admin DN
+// Used only in admin connection mode
+// Default: null
+$config['password_ldap_adminDN'] = null;
+
+// LDAP Admin Password
+// Used only in admin connection mode
+// Default: null
+$config['password_ldap_adminPW'] = null;
+
+// LDAP user DN mask
+// The user's DN is mandatory and as we only have his login,
+// we need to re-create his DN using a mask
+// '%login' will be replaced by the current roundcube user's login
+// '%name' will be replaced by the current roundcube user's name part
+// '%domain' will be replaced by the current roundcube user's domain part
+// '%dc' will be replaced by domain name hierarchal string e.g. "dc=test,dc=domain,dc=com"
+// Exemple: 'uid=%login,ou=people,dc=exemple,dc=com'
+$config['password_ldap_userDN_mask'] = 'uid=%login,ou=people,dc=exemple,dc=com';
+
+// LDAP search DN
+// The DN roundcube should bind with to find out user's DN
+// based on his login. Note that you should comment out the default
+// password_ldap_userDN_mask setting for this to take effect.
+// Use this if you cannot specify a general template for user DN with
+// password_ldap_userDN_mask. You need to perform a search based on
+// users login to find his DN instead. A common reason might be that
+// your users are placed under different ou's like engineering or
+// sales which cannot be derived from their login only.
+$config['password_ldap_searchDN'] = 'cn=roundcube,ou=services,dc=example,dc=com';
+
+// LDAP search password
+// If password_ldap_searchDN is set, the password to use for
+// binding to search for user's DN. Note that you should comment out the default
+// password_ldap_userDN_mask setting for this to take effect.
+// Warning: Be sure to set approperiate permissions on this file so this password
+// is only accesible to roundcube and don't forget to restrict roundcube's access to
+// your directory as much as possible using ACLs. Should this password be compromised
+// you want to minimize the damage.
+$config['password_ldap_searchPW'] = 'secret';
+
+// LDAP search base
+// If password_ldap_searchDN is set, the base to search in using the filter below.
+// Note that you should comment out the default password_ldap_userDN_mask setting
+// for this to take effect.
+$config['password_ldap_search_base'] = 'ou=people,dc=example,dc=com';
+
+// LDAP search filter
+// If password_ldap_searchDN is set, the filter to use when
+// searching for user's DN. Note that you should comment out the default
+// password_ldap_userDN_mask setting for this to take effect.
+// '%login' will be replaced by the current roundcube user's login
+// '%name' will be replaced by the current roundcube user's name part
+// '%domain' will be replaced by the current roundcube user's domain part
+// '%dc' will be replaced by domain name hierarchal string e.g. "dc=test,dc=domain,dc=com"
+// Example: '(uid=%login)'
+// Example: '(&(objectClass=posixAccount)(uid=%login))'
+$config['password_ldap_search_filter'] = '(uid=%login)';
+
+// LDAP password hash type
+// Standard LDAP encryption type which must be one of: crypt,
+// ext_des, md5crypt, blowfish, md5, sha, smd5, ssha, ad, cram-md5 (dovecot style) or clear.
+// Set to 'default' if you want to use method specified in password_algorithm option above.
+// Multiple password Values can be generated by concatenating encodings with a +. E.g. 'cram-md5+crypt'
+// Default: 'crypt'.
+$config['password_ldap_encodage'] = 'crypt';
+
+// LDAP password attribute
+// Name of the ldap's attribute used for storing user password
+// Default: 'userPassword'
+$config['password_ldap_pwattr'] = 'userPassword';
+
+// LDAP password force replace
+// Force LDAP replace in cases where ACL allows only replace not read
+// See http://pear.php.net/package/Net_LDAP2/docs/latest/Net_LDAP2/Net_LDAP2_Entry.html#methodreplace
+// Default: true
+$config['password_ldap_force_replace'] = true;
+
+// LDAP Password Last Change Date
+// Some places use an attribute to store the date of the last password change
+// The date is meassured in "days since epoch" (an integer value)
+// Whenever the password is changed, the attribute will be updated if set (e.g. shadowLastChange)
+$config['password_ldap_lchattr'] = '';
+
+// LDAP Samba password attribute, e.g. sambaNTPassword
+// Name of the LDAP's Samba attribute used for storing user password
+$config['password_ldap_samba_pwattr'] = '';
+
+// LDAP Samba Password Last Change Date attribute, e.g. sambaPwdLastSet
+// Some places use an attribute to store the date of the last password change
+// The date is meassured in "seconds since epoch" (an integer value)
+// Whenever the password is changed, the attribute will be updated if set
+$config['password_ldap_samba_lchattr'] = '';
+
+
+// DirectAdmin Driver options
+// --------------------------
+// The host which changes the password
+// Use 'ssl://host' instead of 'tcp://host' when running DirectAdmin over SSL.
+// The host can contain the following macros that will be expanded as follows:
+//     %h is replaced with the imap host (from the session info)
+//     %d is replaced with the domain part of the username (if the username is an email)
+$config['password_directadmin_host'] = 'tcp://localhost';
+
+// TCP port used for DirectAdmin connections
+$config['password_directadmin_port'] = 2222;
+
+
+// vpopmaild Driver options
+// -----------------------
+// The host which changes the password
+$config['password_vpopmaild_host'] = 'localhost';
+
+// TCP port used for vpopmaild connections
+$config['password_vpopmaild_port'] = 89;
+
+// Timout used for the connection to vpopmaild (in seconds)
+$config['password_vpopmaild_timeout'] = 10;
+
+
+// cPanel Driver options
+// --------------------------
+// The cPanel Host name
+$config['password_cpanel_host'] = 'host.domain.com';
+
+// The cPanel admin username
+$config['password_cpanel_username'] = 'username';
+
+// The cPanel admin password
+$config['password_cpanel_password'] = 'password';
+
+// The cPanel port to use
+$config['password_cpanel_port'] = 2087;
+
+
+// XIMSS (Communigate server) Driver options
+// -----------------------------------------
+// Host name of the Communigate server
+$config['password_ximss_host'] = 'mail.example.com';
+
+// XIMSS port on Communigate server
+$config['password_ximss_port'] = 11024;
+
+
+// chpasswd Driver options
+// ---------------------
+// Command to use (see "Sudo setup" in README)
+$config['password_chpasswd_cmd'] = 'sudo /usr/sbin/chpasswd 2> /dev/null';
+
+
+// XMail Driver options
+// ---------------------
+$config['xmail_host'] = 'localhost';
+$config['xmail_user'] = 'YourXmailControlUser';
+$config['xmail_pass'] = 'YourXmailControlPass';
+$config['xmail_port'] = 6017;
+
+
+// hMail Driver options
+// -----------------------
+// Remote hMailServer configuration
+// true:  HMailserver is on a remote box (php.ini: com.allow_dcom = true)
+// false: Hmailserver is on same box as PHP
+$config['hmailserver_remote_dcom'] = false;
+// Windows credentials
+$config['hmailserver_server'] = array(
+    'Server'   => 'localhost',      // hostname or ip address
+    'Username' => 'administrator',  // windows username
+    'Password' => 'password'        // windows user password
+);
+
+
+// Virtualmin Driver options
+// -------------------------
+// Username format:
+// 0: username@domain
+// 1: username%domain
+// 2: username.domain
+// 3: domain.username
+// 4: username-domain
+// 5: domain-username
+// 6: username_domain
+// 7: domain_username
+$config['password_virtualmin_format'] = 0;
+
+
+// pw_usermod Driver options
+// --------------------------
+// Use comma delimited exlist to disable password change for users.
+// See "Sudo setup" in README file.
+$config['password_pw_usermod_cmd'] = 'sudo /usr/sbin/pw usermod -h 0 -n';
+
+
+// DBMail Driver options
+// -------------------
+// Additional arguments for the dbmail-users call
+$config['password_dbmail_args'] = '-p sha512';
+
+
+// Expect Driver options
+// ---------------------
+// Location of expect binary
+$config['password_expect_bin'] = '/usr/bin/expect';
+
+// Location of expect script (see helpers/passwd-expect)
+$config['password_expect_script'] = '';
+
+// Arguments for the expect script. See the helpers/passwd-expect file for details.
+// This is probably a good starting default:
+//   -telent -host localhost -output /tmp/passwd.log -log /tmp/passwd.log
+$config['password_expect_params'] = '';
+
+
+// smb Driver options
+// ---------------------
+// Samba host (default: localhost)
+// Supported replacement variables:
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
+$config['password_smb_host'] = 'localhost';
+// Location of smbpasswd binary
+$config['password_smb_cmd'] = '/usr/bin/smbpasswd';
+
+// gearman driver options
+// ---------------------
+// Gearman host (default: localhost)
+$config['password_gearman_host'] = 'localhost';
+
+
+// Plesk/PPA Driver options
+// --------------------
+// You need to allow RCP for IP of roundcube-server in Plesk/PPA Panel
+
+// Plesk RCP Host
+$config['password_plesk_host'] = '10.0.0.5';
+
+// Plesk RPC Username
+$config['password_plesk_user'] = 'admin';
+
+// Plesk RPC Password
+$config['password_plesk_pass'] = 'password';
+
+// Plesk RPC Port
+$config['password_plesk_rpc_port'] = '8443';
+
+// Plesk RPC Path
+$config['password_plesk_rpc_path'] = 'enterprise/control/agent.php';
+
+
+// kasswd Driver options
+// ---------------------
+// Command to use
+$config['password_kpasswd_cmd'] = '/usr/bin/kpasswd';

--- a/roles/webmail/templates/roundcube_postgres_initial.sql.j2
+++ b/roles/webmail/templates/roundcube_postgres_initial.sql.j2
@@ -1,0 +1,513 @@
+-- Roundcube Webmail initial database structure
+
+--
+-- Sequence "users_seq"
+-- Name: users_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+SET ROLE {{ webmail_db_username }};
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+        FROM   pg_class c
+        JOIN   pg_namespace n ON n.oid = c.relnamespace
+        WHERE  c.relname = 'users_seq'
+        AND    n.nspname = 'public'
+    ) THEN
+      CREATE SEQUENCE users_seq
+          INCREMENT BY 1
+          NO MAXVALUE
+          NO MINVALUE
+          CACHE 1;
+END IF;
+END$$;
+
+--
+-- Table "users"
+-- Name: users; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS users (
+    user_id integer DEFAULT nextval('users_seq'::text) PRIMARY KEY,
+    username varchar(128) DEFAULT '' NOT NULL,
+    mail_host varchar(128) DEFAULT '' NOT NULL,
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    last_login timestamp with time zone DEFAULT NULL,
+    failed_login timestamp with time zone DEFAULT NULL,
+    failed_login_counter integer DEFAULT NULL,
+    "language" varchar(5),
+    preferences text DEFAULT ''::text NOT NULL,
+    CONSTRAINT users_username_key UNIQUE (username, mail_host)
+);
+
+
+--
+-- Table "session"
+-- Name: session; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS "session" (
+    sess_id varchar(128) DEFAULT '' PRIMARY KEY,
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    changed timestamp with time zone DEFAULT now() NOT NULL,
+    ip varchar(41) NOT NULL,
+    vars text NOT NULL
+);
+
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'session_changed_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX session_changed_idx ON session (changed);
+END IF;
+END$$;
+
+
+--
+-- Sequence "identities_seq"
+-- Name: identities_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+        FROM   pg_class c
+        JOIN   pg_namespace n ON n.oid = c.relnamespace
+        WHERE  c.relname = 'identities_seq'
+        AND    n.nspname = 'public'
+    ) THEN
+      CREATE SEQUENCE identities_seq
+          START WITH 1
+          INCREMENT BY 1
+          NO MAXVALUE
+          NO MINVALUE
+          CACHE 1;
+END IF;
+END$$;
+
+--
+-- Table "identities"
+-- Name: identities; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS identities (
+    identity_id integer DEFAULT nextval('identities_seq'::text) PRIMARY KEY,
+    user_id integer NOT NULL
+        REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    changed timestamp with time zone DEFAULT now() NOT NULL,
+    del smallint DEFAULT 0 NOT NULL,
+    standard smallint DEFAULT 0 NOT NULL,
+    name varchar(128) NOT NULL,
+    organization varchar(128),
+    email varchar(128) NOT NULL,
+    "reply-to" varchar(128),
+    bcc varchar(128),
+    signature text,
+    html_signature integer DEFAULT 0 NOT NULL
+);
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'identities_user_id_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX identities_user_id_idx ON identities (user_id, del);
+END IF;
+END$$;
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'identities_email_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX identities_email_idx ON identities (email, del);
+END IF;
+END$$;
+
+
+--
+-- Sequence "contacts_seq"
+-- Name: contacts_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+        FROM   pg_class c
+        JOIN   pg_namespace n ON n.oid = c.relnamespace
+        WHERE  c.relname = 'contacts_seq'
+        AND    n.nspname = 'public'
+    ) THEN
+      CREATE SEQUENCE contacts_seq
+          START WITH 1
+          INCREMENT BY 1
+          NO MAXVALUE
+          NO MINVALUE
+          CACHE 1;
+END IF;
+END$$;
+
+--
+-- Table "contacts"
+-- Name: contacts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS contacts (
+    contact_id integer DEFAULT nextval('contacts_seq'::text) PRIMARY KEY,
+    user_id integer NOT NULL
+        REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    changed timestamp with time zone DEFAULT now() NOT NULL,
+    del smallint DEFAULT 0 NOT NULL,
+    name varchar(128) DEFAULT '' NOT NULL,
+    email text DEFAULT '' NOT NULL,
+    firstname varchar(128) DEFAULT '' NOT NULL,
+    surname varchar(128) DEFAULT '' NOT NULL,
+    vcard text,
+    words text
+);
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'contacts_user_id_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX contacts_user_id_idx ON contacts (user_id, del);
+END IF;
+END$$;
+
+--
+-- Sequence "contactgroups_seq"
+-- Name: contactgroups_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+        FROM   pg_class c
+        JOIN   pg_namespace n ON n.oid = c.relnamespace
+        WHERE  c.relname = 'contactgroups_seq'
+        AND    n.nspname = 'public'
+    ) THEN
+      CREATE SEQUENCE contactgroups_seq
+          INCREMENT BY 1
+          NO MAXVALUE
+          NO MINVALUE
+          CACHE 1;
+END IF;
+END$$;
+
+--
+-- Table "contactgroups"
+-- Name: contactgroups; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS contactgroups (
+    contactgroup_id integer DEFAULT nextval('contactgroups_seq'::text) PRIMARY KEY,
+    user_id integer NOT NULL
+        REFERENCES users(user_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    changed timestamp with time zone DEFAULT now() NOT NULL,
+    del smallint NOT NULL DEFAULT 0,
+    name varchar(128) NOT NULL DEFAULT ''
+);
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'contactgroups_user_id_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX contactgroups_user_id_idx ON contactgroups (user_id, del);
+END IF;
+END$$;
+
+--
+-- Table "contactgroupmembers"
+-- Name: contactgroupmembers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS contactgroupmembers (
+    contactgroup_id integer NOT NULL
+        REFERENCES contactgroups(contactgroup_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    contact_id integer NOT NULL
+        REFERENCES contacts(contact_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY (contactgroup_id, contact_id)
+);
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'contactgroupmembers_contact_id_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX contactgroupmembers_contact_id_idx ON contactgroupmembers (contact_id);
+END IF;
+END$$;
+
+--
+-- Table "cache"
+-- Name: cache; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS "cache" (
+    user_id integer NOT NULL
+        REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    cache_key varchar(128) DEFAULT '' NOT NULL,
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    expires timestamp with time zone DEFAULT NULL,
+    data text NOT NULL
+);
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'cache_user_id_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX cache_user_id_idx ON "cache" (user_id, cache_key);
+END IF;
+END$$;
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'cache_expires_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX cache_expires_idx ON "cache" (expires);
+END IF;
+END$$;
+
+--
+-- Table "cache_shared"
+-- Name: cache_shared; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS "cache_shared" (
+    cache_key varchar(255) NOT NULL,
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    expires timestamp with time zone DEFAULT NULL,
+    data text NOT NULL
+);
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'cache_shared_cache_key_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX cache_shared_cache_key_idx ON "cache_shared" (cache_key);
+END IF;
+END$$;
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'cache_shared_expires_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX cache_shared_expires_idx ON "cache_shared" (expires);
+END IF;
+END$$;
+
+--
+-- Table "cache_index"
+-- Name: cache_index; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS cache_index (
+    user_id integer NOT NULL
+        REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    mailbox varchar(255) NOT NULL,
+    expires timestamp with time zone DEFAULT NULL,
+    valid smallint NOT NULL DEFAULT 0,
+    data text NOT NULL,
+    PRIMARY KEY (user_id, mailbox)
+);
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'cache_index_expires_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX cache_index_expires_idx ON cache_index (expires);
+END IF;
+END$$;
+
+--
+-- Table "cache_thread"
+-- Name: cache_thread; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS cache_thread (
+    user_id integer NOT NULL
+        REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    mailbox varchar(255) NOT NULL,
+    expires timestamp with time zone DEFAULT NULL,
+    data text NOT NULL,
+    PRIMARY KEY (user_id, mailbox)
+);
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'cache_thread_expires_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX cache_thread_expires_idx ON cache_thread (expires);
+END IF;
+END$$;
+
+--
+-- Table "cache_messages"
+-- Name: cache_messages; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS cache_messages (
+    user_id integer NOT NULL
+        REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    mailbox varchar(255) NOT NULL,
+    uid integer NOT NULL,
+    expires timestamp with time zone DEFAULT NULL,
+    data text NOT NULL,
+    flags integer NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, mailbox, uid)
+);
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'cache_messages_expires_idx'
+    AND    n.nspname = 'public' -- 'public' by default
+    ) THEN
+
+      CREATE INDEX cache_messages_expires_idx ON cache_messages (expires);
+END IF;
+END$$;
+
+--
+-- Table "dictionary"
+-- Name: dictionary; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS dictionary (
+    user_id integer DEFAULT NULL
+        REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
+   "language" varchar(5) NOT NULL,
+    data text NOT NULL,
+    CONSTRAINT dictionary_user_id_language_key UNIQUE (user_id, "language")
+);
+
+--
+-- Sequence "searches_seq"
+-- Name: searches_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+DO $$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1
+        FROM   pg_class c
+        JOIN   pg_namespace n ON n.oid = c.relnamespace
+        WHERE  c.relname = 'users_seq'
+        AND    n.nspname = 'public'
+    ) THEN
+      CREATE SEQUENCE users_seq
+          INCREMENT BY 1
+          NO MAXVALUE
+          NO MINVALUE
+          CACHE 1;
+END IF;
+END$$;
+
+--
+-- Table "searches"
+-- Name: searches; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS searches (
+    search_id integer DEFAULT nextval('searches_seq'::text) PRIMARY KEY,
+    user_id integer NOT NULL
+        REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    "type" smallint DEFAULT 0 NOT NULL,
+    name varchar(128) NOT NULL,
+    data text NOT NULL,
+    CONSTRAINT searches_user_id_key UNIQUE (user_id, "type", name)
+);
+
+
+--
+-- Table "system"
+-- Name: system; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS "system" (
+    name varchar(64) NOT NULL PRIMARY KEY,
+    value text
+);
+
+INSERT INTO system (name, value)  SELECT 'roundcube-version', '2015111100'
+  WHERE NOT EXISTS (SELECT 1 FROM system WHERE name='roundcube-version' AND value='2015111100');

--- a/roles/webmail/templates/roundcube_source.conf.j2
+++ b/roles/webmail/templates/roundcube_source.conf.j2
@@ -1,0 +1,48 @@
+<VirtualHost *:80>
+    ServerName {{ webmail_domain }}
+
+    Redirect permanent / https://{{ webmail_domain }}/
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName {{ webmail_domain }}
+
+    Include /etc/apache2/ssl.conf
+
+    # Those aliases do not work properly with several hosts on your apache server
+    # Uncomment them to use it or adapt them to your configuration
+    # Alias /roundcube/program/js/tiny_mce/ /usr/share/tinymce/www/
+    # Alias /roundcube /var/lib/roundcube
+
+    # Access to tinymce files
+    DocumentRoot /var/lib/roundcube
+
+    <Directory /var/lib/roundcube/>
+      Options +FollowSymLinks
+      # This is needed to parse /var/lib/roundcube/.htaccess. See its
+      # content before setting AllowOverride to None.
+      Require all granted
+    </Directory>
+
+    # Protecting basic directories:
+    <Directory /var/lib/roundcube/config>
+      Options -FollowSymLinks
+      AllowOverride None
+    </Directory>
+
+    <Directory /var/lib/roundcube/temp>
+      Options -FollowSymLinks
+      AllowOverride None
+      Require all denied
+    </Directory>
+
+    <Directory /var/lib/roundcube/logs>
+        Options -FollowSymLinks
+        AllowOverride None
+        Require all denied
+    </Directory>
+
+    CustomLog /var/log/apache2/webmail_access.log combined
+    ErrorLog /var/log/apache2/webmail_error.log
+</VirtualHost>
+

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -108,6 +108,11 @@ openvpn_tls_cipher: "" # "tls-cipher TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256:TLS-E
 # openvpn_clients: (required)
 
 # webmail
+roundcube_version: 1.2.1
+roundcube_plugins:
+  - managesieve
+  - carddav
+  - twofactor_gauthenticator
 webmail_domain: "{{ mail_server_hostname }}"
 webmail_db_username: "roundcube"
 # webmail_db_password: (required)


### PR DESCRIPTION
I'm going to get flamed by the "don't break Debian" crowd, but whatevz. A mailserver with no webmail client is not nearly as useful as a mailserver with one. Ubuntu 14.04 is also stuck on 0.9.5.

This PR installs Roundcube 1.2.1 from (**_gasp_**) SOURCE!

OMG. Unreal. A bunch of PHP scripts in a docroot that we don't need a package maintainer for! Madness! Cats and dogs living together! It's like 1996 again! Let's install Slackware!

This includes a little filter plugin that I needed to get the plugins wrapped in quotes in the template in some fashion that didn't make me want to claw my eyes out. It's called 'wrap' and was not my idea. It came from something on stackoverflow or someplace...DRY, etc.

I'm running this in production, and I (painfully) extracted the core of it today to make this PR. I ran a basic install with default variables and it didn't scream, so it should be good. It's better with my other PRs (password plugin, etc), but those aren't necessary...however, this PR includes previous changes to install the roundcube password plugin because I didn't want to deal w/ manually merging the two branches. I compensated by not activating it - it's just code sitting there, waiting for the user to find it (or for my other PR to be merged).

I _did_ have to hack their db init script so that it can be idempotent and safely run without barfing on every Ansible run.

This may be useful for work being done in #495 and #507.