### PR TITLE
activate imap on trusty.

### DIFF
--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -8,6 +8,10 @@
   tags:
     - dependencies
 
+- name: Enable imap module on Trusty
+  command: php5enmod imap
+  when: ansible_distribution_release == 'trusty'
+
 - name: Download z-push release
   get_url:
     url=http://download.z-push.org/final/2.1/z-push-{{ zpush_version }}.tar.gz


### PR DESCRIPTION
The imap module needs to be enabled on Ubuntu 14.04. Without it z-push doesn't work.

This closes #583.