### PR TITLE
update z-push to new repo-backed version.

### DIFF
--- a/roles/mailserver/files/etc_apache2_conf.d_z-push.conf
+++ b/roles/mailserver/files/etc_apache2_conf.d_z-push.conf
@@ -1,7 +1,42 @@
-Alias /Microsoft-Server-ActiveSync /usr/share/z-push/index.php
+# Z-Push - ActiveSync over-the-air - default Apache configuration
+<IfModule mod_alias.c>
+    Alias /Microsoft-Server-ActiveSync /usr/share/z-push/index.php
+</IfModule>
+
 <Directory /usr/share/z-push>
-    php_flag magic_quotes_gpc off        
-    php_flag register_globals off        
-    php_flag magic_quotes_runtime off        
-    php_flag short_open_tag on    
+    # Don't list a directory index, follow symlinks (maybe state dir is somewhere linked)
+    DirectoryIndex index.php
+    Options -Indexes +FollowSymLinks
+
+    # Z-push requirements
+    php_value magic_quotes_gpc off
+    php_value magic_quotes_runtime off
+    php_value register_globals off
+    php_value short_open_tag on
+
+    # Optional
+    # php_value display_errors off
+
+    # Setting memory limit higher (larger attachments)
+    php_value memory_limit 256M
+
+    # Security
+    # Don't allow .htaccess Overrides, disallow access to files
+    AllowOverride none
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        allow from all
+    </IfModule>
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+
+    <Files "config.php">
+      <IfModule !mod_authz_core.c>
+        Deny from All
+      </IfModule>
+      <IfModule mod_authz_core.c>
+        Require all denied
+      </IfModule>
+    </Files>
 </Directory>

--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -8,28 +8,49 @@
   tags:
     - dependencies
 
-- name: Download z-push release
-  get_url:
-    url=http://download.z-push.org/final/2.1/z-push-{{ zpush_version }}.tar.gz
-    dest=/root/z-push-{{ zpush_version }}.tar.gz
+- name: Enable imap module on Trusty
+  command: php5enmod imap
+  when: ansible_distribution_release == 'trusty'
 
-- name: Decompress z-push source
-  unarchive: src=/root/z-push-{{ zpush_version }}.tar.gz
-             dest=/root copy=no
-             creates=/root/z-push-{{ zpush_version }}
+- name: Convert variable into something we can use for z-push repository
+  shell: echo {{ lookup('template', 'z-push_lookup.j2') }}
+  register: zpush_distro
+  changed_when: False
 
-- name: Create /usr/share/z-push
-  file: state=directory path=/usr/share/z-push
+- name: Add z-push repository ({{ zpush_distro.stdout }})
+  apt_repository: repo='deb http://repo.z-hub.io/z-push:/final/{{ zpush_distro.stdout }}/ /' state=present
+  register: zpush_repo
 
-- name: Copy z-push source files to /usr/share/z-push
-  shell: cp -R z-push-{{ zpush_version }}/* /usr/share/z-push/ chdir=/root
-  tags:
-    - skip_ansible_lint
+- name: Add z-push apt key ({{ zpush_distro.stdout }})
+  apt_key: url=http://repo.z-hub.io/z-push:/final/{{ zpush_distro.stdout }}/Release.key
+  register: zpush_key
 
-- name: Remove downloaded, temporary z-push source files
-  shell: rm -rf z-push* chdir=/root
-  tags:
-    - skip_ansible_lint
+- name: Update apt cache if necessary
+  apt: update_cache=yes
+  when: zpush_repo|changed or zpush_key|changed
+
+# If we just added the repo, we might be installed from source. If so, remove our existing z-push content
+- name: Remove z-push if installed from source
+  file: path={{ item }} state=absent
+  when: zpush_repo|changed
+  with_items:
+    - /usr/share/z-push
+    - /etc/apache2/conf-available/z-push.conf
+    - /etc/apache2/conf-enabled/z-push.conf
+
+- name: Install z-push
+  apt: name={{ item }} state=installed
+  with_items:
+    - z-push-common
+    - z-push-config-apache
+    - z-push-backend-imap
+    - z-push-ipc-sharedmemory
+  register: zpush_installed
+
+# This is from [here](https://wiki.z-hub.io/display/ZP/Upgrade+to+Z-Push+2.3)
+- name: Update states
+  command: z-push-admin -a fixstates
+  when: zpush_installed|changed
 
 - name: Ensure z-push state and log directories are in place
   file: state=directory path={{ item }} owner=www-data group=www-data mode=755
@@ -38,8 +59,11 @@
     - /var/log/z-push
   notify: restart apache
 
-- name: Copy z-push's config.php into place
-  template: src=usr_share_z-push_config.php.j2 dest=/usr/share/z-push/config.php
+- name: Copy z-push's configs into place
+  template: src={{ item.src }} dest={{ item.dest }} owner=www-data group=www-data mode=0640
+  with_items:
+    - { src: "usr_share_z-push_config.php.j2", dest: "/usr/share/z-push/config.php"}
+    - { src: "usr_share_z-push_backend_imap_config.php.j2", dest: "/usr/share/z-push/backend/imap/config.php" }
 
 - name: Configure z-push apache alias and php settings
   copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf.d/z-push.conf
@@ -48,6 +72,7 @@
 
 - name: Create z-push apache alias and php configuration file for Ubuntu Trusty
   copy: src=etc_apache2_conf.d_z-push.conf dest=/etc/apache2/conf-available/z-push.conf
+  notify: restart apache
   when: ansible_distribution_release == 'trusty'
 
 - name: Enable z-push Apache alias and PHP configuration file for Ubuntu Trusty
@@ -55,5 +80,8 @@
   notify: restart apache
   when: ansible_distribution_release == 'trusty'
 
+- name: Remove old z-push logrotate
+  file: path=/etc/logrotate.d/z-push state=absent
+
 - name: Configure z-push logrotate
-  copy: src=etc_logrotate_z-push dest=/etc/logrotate.d/z-push owner=root group=root mode=0644
+  copy: src=etc_logrotate_z-push dest=/etc/logrotate.d/z-push.lr owner=root group=root mode=0644

--- a/roles/mailserver/templates/usr_share_z-push_backend_imap_config.php.j2
+++ b/roles/mailserver/templates/usr_share_z-push_backend_imap_config.php.j2
@@ -1,0 +1,230 @@
+<?php
+/***********************************************
+* File      :   config.php
+* Project   :   Z-Push
+* Descr     :   IMAP backend configuration file
+*
+* Created   :   27.11.2012
+*
+* Copyright 2007 - 2013 Zarafa Deutschland GmbH
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License, version 3,
+* as published by the Free Software Foundation with the following additional
+* term according to sec. 7:
+*
+* According to sec. 7 of the GNU Affero General Public License, version 3,
+* the terms of the AGPL are supplemented with the following terms:
+*
+* "Zarafa" is a registered trademark of Zarafa B.V.
+* "Z-Push" is a registered trademark of Zarafa Deutschland GmbH
+* The licensing of the Program under the AGPL does not imply a trademark license.
+* Therefore any rights, title and interest in our trademarks remain entirely with us.
+*
+* However, if you propagate an unmodified version of the Program you are
+* allowed to use the term "Z-Push" to indicate that you distribute the Program.
+* Furthermore you may use our trademarks where it is necessary to indicate
+* the intended purpose of a product or service provided you use it in accordance
+* with honest practices in industrial or commercial matters.
+* If you want to propagate modified versions of the Program under the name "Z-Push",
+* you may only do so if you have a written permission by Zarafa Deutschland GmbH
+* (to acquire a permission please contact Zarafa at trademark@zarafa.com).
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* Consult LICENSE file for details
+************************************************/
+
+// ************************
+//  BackendIMAP settings
+// ************************
+
+// Defines the server to which we want to connect
+define('IMAP_SERVER', 'localhost');
+
+// connecting to default port (143)
+define('IMAP_PORT', 993);
+
+// best cross-platform compatibility (see http://php.net/imap_open for options)
+// define('IMAP_OPTIONS', '/notls/norsh');
+    // best cross-platform compatibility (see http://php.net/imap_open for options)
+define('IMAP_OPTIONS', '/ssl/novalidate-cert');
+
+
+// Mark messages as read when moving to Trash.
+//      BE AWARE that you will lose the unread flag, but some mail clients do this so the Trash folder doesn't get boldened
+define('IMAP_AUTOSEEN_ON_DELETE', false);
+
+
+// IMPORTANT: BASIC IMAP FOLDERS [ask your mail admin]
+        // We can have diferent cases (case insensitive):
+        // 1.
+        //      inbox
+        //      sent
+        //      drafts
+        //      trash
+        // 2.
+        //      inbox
+        //      common.sent
+        //      common.drafts
+        //      common.trash
+        // 3.
+        //      common.inbox
+        //      common.sent
+        //      common.drafts
+        //      common.trash
+        // 4.
+        //      common
+        //      common.sent
+        //      common.drafts
+        //      common.trash
+        //
+        // gmail is a special case, where the default folders are under the [gmail] prefix and the folders defined by the user are under INBOX.
+        // This configuration seems to work:
+        //      define('IMAP_FOLDER_PREFIX', '');
+        //      define('IMAP_FOLDER_PREFIX_IN_INBOX', false);
+        //      define('IMAP_FOLDER_INBOX', 'INBOX');
+        //      define('IMAP_FOLDER_SENT', '[Gmail]/Sent');
+        //      define('IMAP_FOLDER_DRAFT', '[Gmail]/Drafts');
+        //      define('IMAP_FOLDER_TRASH', '[Gmail]/Trash');
+        //      define('IMAP_FOLDER_SPAM', '[Gmail]/Spam');
+        //      define('IMAP_FOLDER_ARCHIVE', '[Gmail]/All Mail');
+
+// Since I know you won't configure this, I will raise an error unless you do.
+// When configured set this to true to remove the error
+define('IMAP_FOLDER_CONFIGURED', true);
+
+// Folder prefix is the common part in your names (3, 4)
+define('IMAP_FOLDER_PREFIX', '');
+
+// Inbox will have the preffix preppend (3 & 4 to true)
+define('IMAP_FOLDER_PREFIX_IN_INBOX', false);
+
+// Inbox folder name (case doesn't matter) - (empty in 4)
+define('IMAP_FOLDER_INBOX', 'INBOX');
+
+// Sent folder name (case doesn't matter)
+define('IMAP_FOLDER_SENT', 'SENT');
+
+// Draft folder name (case doesn't matter)
+define('IMAP_FOLDER_DRAFT', 'DRAFTS');
+
+// Trash folder name (case doesn't matter)
+define('IMAP_FOLDER_TRASH', 'TRASH');
+
+// Spam folder name (case doesn't matter). Only showed as special by iOS devices
+define('IMAP_FOLDER_SPAM', 'SPAM');
+
+// Archive folder name (case doesn't matter). Only showed as special by iOS devices
+define('IMAP_FOLDER_ARCHIVE', 'ARCHIVE');
+
+
+
+// forward messages inline (default true - inlined)
+define('IMAP_INLINE_FORWARD', true);
+
+// list of folders we want to exclude from sync. Names, or part of it, separated by |
+// example: dovecot.sieve|archive|spam
+define('IMAP_EXCLUDED_FOLDERS', 'dovecot.sieve');
+
+
+
+// overwrite the "from" header with some value
+// options:
+//        ''              - do nothing, use the From header
+//        'username'      - the username will be set (usefull if your login is equal to your emailaddress)
+//        'domain'        - the value of the "domain" field is used
+//        'sql'           - the username will be the result of a sql query. REMEMBER TO INSTALL PHP-PDO AND PHP-DATABASE
+//        'ldap'          - the username will be the result of a ldap query. REMEMBER TO INSTALL PHP-LDAP!!
+//        '@mydomain.com' - the username is used and the given string will be appended
+define('IMAP_DEFAULTFROM', '');
+
+// DSN: formatted PDO connection string
+//    mysql:host=xxx;port=xxx;dbname=xxx
+// USER: username to DB
+// PASSWORD: password to DB
+// OPTIONS: array with options needed
+// QUERY: query to execute
+// FIELDS: columns in the query
+// FROM: string that will be the from, replacing the column names with the values
+define('IMAP_FROM_SQL_DSN', '');
+define('IMAP_FROM_SQL_USER', '');
+define('IMAP_FROM_SQL_PASSWORD', '');
+define('IMAP_FROM_SQL_OPTIONS', serialize(array(PDO::ATTR_PERSISTENT => true)));
+define('IMAP_FROM_SQL_QUERY', "select first_name, last_name, mail_address from users where mail_address = '#username@#domain'");
+define('IMAP_FROM_SQL_FIELDS', serialize(array('first_name', 'last_name', 'mail_address')));
+define('IMAP_FROM_SQL_FROM', '#first_name #last_name <#mail_address>');
+define('IMAP_FROM_SQL_FULLNAME', '#first_name #last_name');
+
+// SERVER: ldap server
+// SERVER_PORT: ldap port
+// USER: dn to use for connecting
+// PASSWORD: password
+// QUERY: query to execute
+// FIELDS: columns in the query
+// FROM: string that will be the from, replacing the field names with the values
+define('IMAP_FROM_LDAP_SERVER', 'localhost');
+define('IMAP_FROM_LDAP_SERVER_PORT', '389');
+define('IMAP_FROM_LDAP_USER', 'cn=zpush,ou=servers,dc=zpush,dc=org');
+define('IMAP_FROM_LDAP_PASSWORD', 'password');
+define('IMAP_FROM_LDAP_BASE', 'dc=zpush,dc=org');
+define('IMAP_FROM_LDAP_QUERY', '(mail=#username@#domain)');
+define('IMAP_FROM_LDAP_FIELDS', serialize(array('givenname', 'sn', 'mail')));
+define('IMAP_FROM_LDAP_FROM', '#givenname #sn <#mail>');
+define('IMAP_FROM_LDAP_FULLNAME', '#givenname #sn');
+
+
+
+// Method used for sending mail
+// mail => mail() php function
+// sendmail => sendmail executable
+// smtp => direct connection against SMTP
+define('IMAP_SMTP_METHOD', 'mail');
+
+global $imap_smtp_params;
+// SMTP Parameters
+//      mail : no params
+$imap_smtp_params = array();
+//      sendmail
+//$imap_smtp_params = array('sendmail_path' => '/usr/bin/sendmail', 'sendmail_args' => '-i');
+//      smtp
+//          "host"              - The server to connect. Default is localhost.
+//          "port"              - The port to connect. Default is 25.
+//          "auth"              - Whether or not to use SMTP authentication. Default is FALSE.
+//          "username"          - The username to use for SMTP authentication. "imap_username" for using the same username as the imap server
+//          "password"          - The password to use for SMTP authentication. "imap_password" for using the same password as the imap server
+//          "localhost"         - The value to give when sending EHLO or HELO. Default is localhost
+//          "timeout"           - The SMTP connection timeout. Default is NULL (no timeout).
+//          "verp"              - Whether to use VERP or not. Default is FALSE.
+//          "debug"             - Whether to enable SMTP debug mode or not. Default is FALSE.
+//          "persist"           - Indicates whether or not the SMTP connection should persist over multiple calls to the send() method.
+//          "pipelining"        - Indicates whether or not the SMTP commands pipelining should be used.
+//          "verify_peer"       - Require verification of SSL certificate used. Default is TRUE.
+//          "verify_peer_name"  - Require verification of peer name. Default is TRUE.
+//          "allow_self_signed" - Allow self-signed certificates. Requires verify_peer. Default is FALSE.
+//$imap_smtp_params = array('host' => 'localhost', 'port' => 25, 'auth' => false);
+// If you want to use SSL with port 25 or port 465 you must preppend "ssl://" before the hostname or IP of your SMTP server
+// IMPORTANT: To use SSL you must use PHP 5.1 or later, install openssl libs and use ssl:// within the host variable
+// IMPORTANT: To use SSL with PHP 5.6 you should set verify_peer, verify_peer_name and allow_self_signed
+//$imap_smtp_params = array('host' => 'ssl://localhost', 'port' => 465, 'auth' => true, 'username' => 'imap_username', 'password' => 'imap_password');
+
+
+
+// If you are using IMAP_SMTP_METHOD = mail or sendmail and your sent messages are not correctly displayed you can change this to "\n".
+//   BUT, it doesn't comply with RFC 2822 and will break if using smtp method
+define('MAIL_MIMEPART_CRLF', "\r\n");
+
+
+// A file containing file mime types->extension mappings.
+//  SELINUX users: make sure the file has a security context accesible by your apache/php-fpm process
+define('SYSTEM_MIME_TYPES_MAPPING', '/etc/mime.types');
+
+
+// Use BackendCalDAV for Meetings. You cannot hope to get that functionality working without a caldav backend.
+define('IMAP_MEETING_USE_CALDAV', false);

--- a/roles/mailserver/templates/usr_share_z-push_config.php.j2
+++ b/roles/mailserver/templates/usr_share_z-push_config.php.j2
@@ -6,7 +6,7 @@
 *
 * Created   :   01.10.2007
 *
-* Copyright 2007 - 2013 Zarafa Deutschland GmbH
+* Copyright 2007 - 2016 Zarafa Deutschland GmbH
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License, version 3,
@@ -60,14 +60,45 @@
     // This setting specifies the owner parameter in the certificate to look at.
     define("CERTIFICATE_OWNER_PARAMETER", "SSL_CLIENT_S_DN_CN");
 
+    /*
+     * Whether to use the complete email address as a login name
+     * (e.g. user@company.com) or the username only (user).
+     * This is required for Z-Push to work properly after autodiscover.
+     * Possible values:
+     *   false - use the username only.
+     *   true  - string the mobile sends as username, e.g. full email address (default).
+     */
+    define('USE_FULLEMAIL_FOR_LOGIN', true);
+
 /**********************************************************************************
- *  Default FileStateMachine settings
+ * StateMachine setting
+ *
+ * These StateMachines can be used:
+ *   FILE  - FileStateMachine (default). Needs STATE_DIR set as well.
+ *   SQL   - SqlStateMachine has own configuration file. STATE_DIR is ignored.
+ *           State migration script is available, more informations: https://wiki.z-hub.io/x/xIAa
  */
+    define('STATE_MACHINE', 'FILE');
     define('STATE_DIR', '/decrypted/zpush-state/');
 
+/**********************************************************************************
+ *  IPC - InterProcessCommunication
+ *
+ *  Is either provided by using shared memory on a single host or
+ *  using the memcache provider for multi-host environments.
+ *  When another implementation should be used, the class can be set here explicitly.
+ *  If empty Z-Push will try to use available providers.
+ */
+    define('IPC_PROVIDER', '');
 
 /**********************************************************************************
  *  Logging settings
+ *
+ *  The LOGBACKEND specifies where the logs are sent to.
+ *  Either to file ("filelog") or to a "syslog" server or a custom log class in core/log/logclass.
+ *  filelog and syslog have several options that can be set below.
+ *  For more information about the syslog configuration, see https://wiki.z-hub.io/x/HIAT
+
  *  Possible LOGLEVEL and LOGUSERLEVEL values are:
  *  LOGLEVEL_OFF            - no logging
  *  LOGLEVEL_FATAL          - log only critical errors
@@ -82,13 +113,13 @@
  *  The verbosity increases from top to bottom. More verbose levels include less verbose
  *  ones, e.g. setting to LOGLEVEL_DEBUG will also output LOGLEVEL_FATAL, LOGLEVEL_ERROR,
  *  LOGLEVEL_WARN and LOGLEVEL_INFO level entries.
+ *
+ *  LOGAUTHFAIL is logged to the LOGBACKEND.
  */
-    define('LOGFILEDIR', '/var/log/z-push/');
-    define('LOGFILE', LOGFILEDIR . 'z-push.log');
-    define('LOGERRORFILE', LOGFILEDIR . 'z-push-error.log');
+
+    define('LOGBACKEND', 'filelog');
     define('LOGLEVEL', LOGLEVEL_INFO);
     define('LOGAUTHFAIL', false);
-
 
     // To save e.g. WBXML data only for selected users, add the usernames to the array
     // The data will be saved into a dedicated file per user in the LOGFILEDIR
@@ -96,6 +127,21 @@
     //   $specialLogUsers = array('info@domain.com', 'myusername');
     define('LOGUSERLEVEL', LOGLEVEL_DEVICEID);
     $specialLogUsers = array();
+
+    // Filelog settings
+    define('LOGFILEDIR', '/var/log/z-push/');
+    define('LOGFILE', LOGFILEDIR . 'z-push.log');
+    define('LOGERRORFILE', LOGFILEDIR . 'z-push-error.log');
+
+    // Syslog settings
+    // false will log to local syslog, otherwise put the remote syslog IP here
+    define('LOG_SYSLOG_HOST', false);
+    // Syslog port
+    define('LOG_SYSLOG_PORT', 514);
+    // Program showed in the syslog. Useful if you have more than one instance login to the same syslog
+    define('LOG_SYSLOG_PROGRAM', 'z-push');
+    // Syslog facility - use LOG_USER when running on Windows
+    define('LOG_SYSLOG_FACILITY', LOG_LOCAL0);
 
     // Location of the trusted CA, e.g. '/etc/ssl/certs/EmailCA.pem'
     // Uncomment and modify the following line if the validation of the certificates fails.
@@ -112,6 +158,10 @@
     // false (default) - Enforce provisioning for all devices
     // true - allow older devices, but enforce policies on devices which support it
     define('LOOSE_PROVISIONING', false);
+
+    // The file containing the policies' settings.
+    // Set a full path or relative to the z-push main directory
+    define('PROVISIONING_POLICYFILE', 'policies.ini');
 
     // Default conflict preference
     // Some devices allow to set if the server or PIM (mobile)
@@ -135,11 +185,6 @@
     // a higher value if you have a high load on the server.
     define('PING_INTERVAL', 30);
 
-    // Interval in seconds to force a re-check of potentially missed notifications when
-    // using a changes sink. Default are 300 seconds (every 5 min).
-    // This can also be disabled by setting it to false
-    define('SINK_FORCERECHECK', 300);
-
     // Set the fileas (save as) order for contacts in the webaccess/webapp/outlook.
     // It will only affect new/modified contacts on the mobile which then are synced to the server.
     // Possible values are:
@@ -158,11 +203,13 @@
     // SYNC_FILEAS_LASTFIRST will be used
     define('FILEAS_ORDER', SYNC_FILEAS_LASTFIRST);
 
-    // Amount of items to be synchronized per request
+    // Maximum amount of items to be synchronized per request.
     // Normally this value is requested by the mobile. Common values are 5, 25, 50 or 100.
     // Exporting too much items can cause mobile timeout on busy systems.
-    // Z-Push will use the lowest value, either set here or by the mobile.
-    // default: 100 - value used if mobile does not limit amount of items
+    // Z-Push will use the lowest provided value, either set here or by the mobile.
+    // MS Outlook 2013+ request up to 512 items to accelerate the sync process.
+    // If you detect high load (also on subsystems) you could try a lower setting.
+    // max: 512 - value used if mobile does not limit amount of items
     define('SYNC_MAX_ITEMS', 100);
 
     // The devices usually send a list of supported properties for calendar and contact
@@ -172,7 +219,7 @@
     // to tell if a property was deleted or it was not set at all if it does not appear in Sync.
     // This parameter defines Z-Push behaviour during Sync if a device does not issue a list with
     // supported properties.
-    // See also https://jira.zarafa.com/browse/ZP-302.
+    // See also https://jira.z-hub.io/browse/ZP-302.
     // Possible values:
     // false - do not unset properties which are not sent during Sync (default)
     // true  - unset properties which are not sent during Sync
@@ -182,58 +229,55 @@
     // in the semantic sanity checks and contacts with larger photos are not synchronized.
     // This limitation is not being followed by the ActiveSync clients which set much bigger
     // contact photos. You can override the default value of the max photo size.
-    // default: 49152 - 48 KB default max photo size in bytes
+    // default: 5242880 - 5 MB default max photo size in bytes
     define('SYNC_CONTACTS_MAXPICTURESIZE', 49152);
+
+    // Over the WebserviceUsers command it is possible to retrieve a list of all
+    // known devices and users on this Z-Push system. The authenticated user needs to have
+    // admin rights and a public folder must exist.
+    // In multicompany environments this enable an admin user of any company to retrieve
+    // this full list, so this feature is disabled by default. Enable with care.
+    define('ALLOW_WEBSERVICE_USERS_ACCESS', false);
+
+    // Users with many folders can use the 'partial foldersync' feature, where the server
+    // actively stops processing the folder list if it takes too long. Other requests are
+    // then redirected to the FolderSync to synchronize the remaining items.
+    // Device compatibility for this procedure is not fully understood.
+    // NOTE: THIS IS AN EXPERIMENTAL FEATURE WHICH COULD PREVENT YOUR MOBILES FROM SYNCHRONIZING.
+    define('USE_PARTIAL_FOLDERSYNC', false);
+
+    // The minimum accepted time in second that a ping command should last.
+    // It is strongly advised to keep this config to false. Some device
+    // might not be able to send a higher value than the one specificied here and thus
+    // unable to start a push connection.
+    // If set to false, there will be no lower bound to the ping lifetime.
+    // The minimum accepted value is 1 second. The maximum accepted value is 3540 seconds (59 minutes).
+    define('PING_LOWER_BOUND_LIFETIME', false);
+
+    // The maximum accepted time in second that a ping command should last.
+    // If set to false, there will be no higher bound to the ping lifetime.
+    // The minimum accepted value is 1 second. The maximum accepted value is 3540 seconds (59 minutes).
+    define('PING_HIGHER_BOUND_LIFETIME', false);
+
+    // Maximum response time
+    // Mobiles implement different timeouts to their TCP/IP connections. Android devices for example
+    // have a hard timeout of 30 seconds. If the server is not able to answer a request within this timeframe,
+    // the answer will not be recieved and the device will send a new one overloading the server.
+    // There are three categories
+    //   - Short timeout  - server has up within 30 seconds - is automatically applied for not categorized types
+    //   - Medium timeout - server has up to 90 seconds to respond
+    //   - Long timeout   - server has up to 4 minutes to respond
+    // If a timeout is almost reached the server will break and sent the results it has until this
+    // point. You can add DeviceType strings to the categories.
+    // In general longer timeouts are better, because more data can be streamed at once.
+    define('SYNC_TIMEOUT_MEDIUM_DEVICETYPES', "SAMSUNGGTI");
+    define('SYNC_TIMEOUT_LONG_DEVICETYPES',   "iPod, iPad, iPhone, WP, WindowsOutlook");
 
 /**********************************************************************************
  *  Backend settings
  */
     // the backend data provider
     define('BACKEND_PROVIDER', 'BackendIMAP');
-
-
-    // ************************
-    //  BackendZarafa settings
-    // ************************
-    // Defines the server to which we want to connect
-    define('MAPI_SERVER', 'file:///var/run/zarafa');
-
-
-    // ************************
-    //  BackendIMAP settings
-    // ************************
-    // Defines the server to which we want to connect
-    define('IMAP_SERVER', 'localhost');
-    // connecting to default port (143)
-    define('IMAP_PORT', 993);
-    // best cross-platform compatibility (see http://php.net/imap_open for options)
-    define('IMAP_OPTIONS', '/ssl/novalidate-cert');
-    // overwrite the "from" header if it isn't set when sending emails
-    // options: 'username'    - the username will be set (usefull if your login is equal to your emailaddress)
-    //        'domain'    - the value of the "domain" field is used
-    //        '@mydomain.com' - the username is used and the given string will be appended
-    define('IMAP_DEFAULTFROM', '');
-    // copy outgoing mail to this folder. If not set d-push will try the default folders
-    define('IMAP_SENTFOLDER', 'Sent');
-    // forward messages inline (default false - as attachment)
-    define('IMAP_INLINE_FORWARD', false);
-    // don't use imap_mail() to send emails.
-    // true (default, uses imap_mail, which is broken - false uses mail(),
-    // which handles cc and from in a more sane way)
-    define('IMAP_USE_IMAPMAIL', false);
-
-
-    // ************************
-    //  BackendMaildir settings
-    // ************************
-    define('MAILDIR_BASE', '/tmp');
-    define('MAILDIR_SUBDIR', 'Maildir');
-
-    // **********************
-    //  BackendVCardDir settings
-    // **********************
-    define('VCARDDIR_DIR', '/home/%u/.kde/share/apps/kabc/stdvcf');
-
 
 /**********************************************************************************
  *  Search provider settings
@@ -251,6 +295,35 @@
     // might result in timeout. Default is 10.
     define('SEARCH_MAXRESULTS', 10);
 
+/**********************************************************************************
+ *  Kopano Outlook Extension - Settings
+ *
+ *  The Kopano Outlook Extension (KOE) provides MS Outlook 2013 and newer with
+ *  functionality not provided by ActiveSync or not implemented by Outlook.
+ *  For more information, see: https://wiki.z-hub.io/x/z4Aa
+ */
+    // Global Address Book functionality
+    define('KOE_CAPABILITY_GAB', true);
+    // Synchronize mail flags from the server to Outlook/KOE
+    define('KOE_CAPABILITY_RECEIVEFLAGS', true);
+    // Encode flags when sending from Outlook/KOE
+    define('KOE_CAPABILITY_SENDFLAGS', true);
+    // Out-of-office support
+    define('KOE_CAPABILITY_OOF', true);
+    // Out-of-office support with start & end times (superseeds KOE_CAPABILITY_OOF)
+    define('KOE_CAPABILITY_OOFTIMES', true);
+    // Notes support
+    define('KOE_CAPABILITY_NOTES', true);
+    // Shared folder support
+    define('KOE_CAPABILITY_SHAREDFOLDER', true);
+
+    // To synchronize the GAB KOE, the GAB store and folderid need to be specified.
+    // Use the gab-sync script to generate this data. The name needs to
+    // match the config of the gab-sync script.
+    // More information here: https://wiki.z-hub.io/x/z4Aa (GAB Sync Script)
+    define('KOE_GAB_STORE', 'SYSTEM');
+    define('KOE_GAB_FOLDERID', '');
+    define('KOE_GAB_NAME', 'Z-Push-KOE-GAB');
 
 /**********************************************************************************
  *  Synchronize additional folders to all mobiles
@@ -264,7 +337,7 @@
  *
  *  To synchronize a folder, add a section setting all parameters as below:
  *      store:      the ressource where the folder is located.
- *                  Zarafa users use 'SYSTEM' for the 'Public Folder'
+ *                  Kopano users use 'SYSTEM' for the 'Public Folder'
  *      folderid:   folder id of the folder to be synchronized
  *      name:       name to be displayed on the mobile device
  *      type:       supported types are:
@@ -272,13 +345,14 @@
  *                      SYNC_FOLDER_TYPE_USER_APPOINTMENT
  *                      SYNC_FOLDER_TYPE_USER_TASK
  *                      SYNC_FOLDER_TYPE_USER_MAIL
+ *                      SYNC_FOLDER_TYPE_USER_NOTE
  *
  *  Additional notes:
- *  - on Zarafa systems use backend/zarafa/listfolders.php script to get a list
+ *  - on Kopano systems use backend/kopano/listfolders.php script to get a list
  *    of available folders
  *
- *  - all Z-Push users must have full writing permissions (secretary rights) so
- *    the configured folders can be synchronized to the mobile
+ *  - all Z-Push users must have at least reading permissions so the configured
+ *    folders can be synchronized to the mobile. Else they are ignored.
  *
  *  - this feature is only partly suitable for multi-tenancy environments,
  *    as ALL users from ALL tenents need access to the configured store & folder.
@@ -302,5 +376,3 @@
         ),
 */
     );
-
-?>

--- a/roles/mailserver/templates/z-push_lookup.j2
+++ b/roles/mailserver/templates/z-push_lookup.j2
@@ -1,0 +1,16 @@
+{#
+ # This template is used by the z-push playbook to
+ # determine a name for our distribution that we
+ # can use for the apt repo and key. It prevents us from
+ # having 6 duplicate plays for the same thing when only
+ # the name portion of the path changes.
+#}
+{% if ansible_distribution_release == 'trusty' %}
+Ubuntu_14.04
+{% elif ansible_distribution_release == 'wheezy' %}
+Debian_7.0
+{% elif ansible_distribution_release == 'jessie' %}
+Debian_8.0
+{% else %}
+UNKNOWN
+{% endif %}


### PR DESCRIPTION
This PR will remove any existing source installation of z-push and install it from their new Ubuntu/Debian repos. It also splits out the configuration into the new backend-specific configuration and installs all the requisite packages.

I have this running in production under Ubuntu 14.04.

This closes #584.