### PR TITLE
Update Rspamd setup

### DIFF
--- a/roles/mailserver/handlers/main.yml
+++ b/roles/mailserver/handlers/main.yml
@@ -18,7 +18,7 @@
   service: name=opendmarc state=restarted
 
 - name: restart rspamd
-  service: name=rspamd.socket state=restarted
+  service: name=rspamd state=restarted
 
 - name: import opendmarc schema
   mysql_db: name={{ mail_db_opendmarc_database }} state=import target=/usr/share/doc/opendmarc/schema.mysql

--- a/roles/mailserver/tasks/rspamd.yml
+++ b/roles/mailserver/tasks/rspamd.yml
@@ -30,7 +30,7 @@
   service: name=redis-server state=started
 
 - name: Start rspamd systemd socket listener
-  service: name=rspamd.socket state=started
+  service: name=rspamd state=started
 
 - name: Start rmilter systemd socket listener
   service: name=rmilter.socket state=started


### PR DESCRIPTION
Rspamd changed the recommended way of starting its services, thus the playbook is failing on this task.

References:
- https://github.com/vstakhov/rspamd/pull/762
- https://rspamd.com/doc/quickstart.html#running-rspamd

> Packaging should start rspamd and configure it to run on startup on installation.