### PR TITLE
Reinstate webmail role (take 2)

### DIFF
--- a/roles/webmail/DESIGN.md
+++ b/roles/webmail/DESIGN.md
@@ -1,0 +1,17 @@
+# Overview
+
+This role installs the Roundcube package to enable browser-based email handling. This is useful if you need to access email with something other than your own computer or smart phone.  It is also the only friendly way in Sovereign to edit sieve filters for email.
+
+Roundcube is stable and continues to be actively developed.
+
+# Install
+
+The role installs roundcube from the source package released by the Roundcube team.  The version is pinned.  Old versions of this role installed Roundcube from apt packages, but the packages for Debian 8 do not install unattended correctly unless mysql is used at the backend.  We want to use only one database server (postgres) to save on RAM, so using packages is not an option for now.
+
+Roundcube is installed with sqlite3 for its persistence layer.  This eliminates dependency on a database server and likely improves performance given how little persistet data Roundcube keeps.  Roundcube automatically looks for the database file and intializes it if it is missing.  The file is kept on `/decrypted` since it contains user data, and the database will be backed up automatically if the tarsnap role is used.
+
+PHP composer is used for downloading and installing plugins.  Configuration files are kept with sovereign.  The configuration files for `twofactor_gauthentication` and `carddav` are not modified from their defaults.  I chose to do this so that maintainers could recognize when configuration files change in future plugin versions and decide whether or not to change new defaults.
+
+# Upgrade
+
+It's unknown how upgrades will be handled.  The best case is that an update can be installed over the current version, and code will automatically update the database the first time it connects.  This needs to be considered for plugins that store data also.

--- a/roles/webmail/defaults/main.yml
+++ b/roles/webmail/defaults/main.yml
@@ -1,0 +1,5 @@
+webmail_version: 1.2.1
+
+# Keep in sync with mail_server_hostname in mailserver role
+webmail_domain: "mail.{{ domain }}"
+

--- a/roles/webmail/files/var_www_roundcube_composer.json
+++ b/roles/webmail/files/var_www_roundcube_composer.json
@@ -1,0 +1,45 @@
+{
+    "name": "roundcube/roundcubemail",
+    "description": "The Roundcube Webmail suite",
+    "license": "GPL-3.0+",
+    "repositories": [
+        {
+            "type": "pear",
+            "url": "https://pear.php.net/"
+        },
+        {
+            "type": "composer",
+            "url": "https://plugins.roundcube.net/"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/roundcube/Net_Sieve.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://git.kolab.org/diffusion/PNL/php-net_ldap.git"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.7",
+        "pear/pear-core-minimal": "~1.10.1",
+        "roundcube/plugin-installer": "~0.1.6",
+        "pear-pear.php.net/net_socket": "~1.0.12",
+        "pear-pear.php.net/auth_sasl": "~1.0.6",
+        "pear-pear.php.net/net_idna2": "~0.1.1",
+        "pear-pear.php.net/mail_mime": "~1.10.0",
+        "pear-pear.php.net/net_smtp": "~1.7.1",
+        "pear-pear.php.net/crypt_gpg": "~1.4.2",
+        "roundcube/net_sieve": "~1.5.0",
+        "alexandregz/twofactor_gauthenticator": "dev-master",
+	"roundcube/carddav": "dev-master"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "*"
+    },
+    "suggest": {
+        "pear-pear.php.net/net_ldap2": "~2.2.0 required for connecting to LDAP address books",
+        "kolab/Net_LDAP3": "dev-master required for connecting to LDAP address books"
+    },
+    "minimum-stability": "dev"
+}

--- a/roles/webmail/files/var_www_roundcube_config_global.sieve
+++ b/roles/webmail/files/var_www_roundcube_config_global.sieve
@@ -1,0 +1,11 @@
+require ["regex", "fileinto", "imap4flags"];
+# Catch mail tagged as Spam, except Spam retrained and delivered to the mailbox
+if allof (header :regex "X-DSPAM-Result" "^(Spam|Virus|Bl[ao]cklisted)$",
+          not header :contains "X-DSPAM-Reclassified" "Innocent") {
+  # Mark as read
+  setflag "\\Seen";
+  # Move into the Junk folder
+  fileinto "Spam";
+  # Stop processing here
+  stop;
+}

--- a/roles/webmail/files/var_www_roundcube_plugins_carddav_config.inc.php
+++ b/roles/webmail/files/var_www_roundcube_plugins_carddav_config.inc.php
@@ -1,0 +1,185 @@
+<?php
+
+//// RCMCardDAV Plugin Admin Settings
+
+//// ** GLOBAL SETTINGS
+
+// Disallow users to add / edit / delete custom addressbooks (default: false)
+//
+// If true, User cannot add custom addressbooks
+// If false, user can add / edit / delete custom addressbooks
+//
+// This option only affects custom addressbooks. Preset addressbooks (see below)
+// are not affected.
+// $prefs['_GLOBAL']['fixed'] = true;
+
+// When enabled, this option hides the 'CardDAV' section inside Preferences.
+// $prefs['_GLOBAL']['hide_preferences'] = true;
+
+// Scheme for storing the CardDAV passwords, in order from least to best security.
+// Options:
+// plain: store as plaintext
+// base64: store encoded with base64 (default)
+// des_key: store encrypted with global des_key of roundcube
+// encrypted: store encrypted with IMAP password of the user
+//            NOTE: if the IMAP password of the user changes, the stored
+//             CardDAV passwords cannot be decrypted anymore and the user
+//             needs to reenter them.
+// $prefs['_GLOBAL']['pwstore_scheme'] = 'base64';
+
+//// ** ADDRESSBOOK PRESETS
+
+// Each addressbook preset takes the following form:
+/*
+$prefs['<Presetname>'] = array(
+	// required attributes
+	'name'         =>  '<Addressbook Name>',
+	'username'     =>  '<CardDAV Username>',
+	'password'     =>  '<CardDAV Password>',
+	'url'          =>  '<CardDAV URL>',
+
+	// optional attributes
+	'active'       =>  <true or false>,
+	'readonly'     =>  <true or false>,
+	'refresh_time' => '<Refresh Time in Hours, Format HH[:MM[:SS]]>',
+
+	// attributes that are fixed (i.e., not editable by the user) and
+	// auto-updated for this preset
+	'fixed'        =>  array( < 0 or more of the other attribute keys > ),
+
+	// hide this preset from CalDAV preferences section so users can't even
+	// see it
+	'hide' => <true or false>,
+);
+*/
+
+// All values in angle brackets <VALUE> have to be substituted.
+//
+// The meaning of the different parameters is as follows:
+//
+// <Presetname>: Unique preset name, must not be '_GLOBAL'. The presetname is
+//               not user visible and only used for an internal mapping between
+//               addressbooks created from a preset and the preset itself. You
+//               should never change this throughout its lifetime.
+//
+// The following parameters are REQUIRED and need to be specified for any preset.
+//
+// name:         User-visible name of the addressbook. If the server provides
+//               an additional display name for the addressbooks found for the
+//               preset, it will be appended in brackets to this name, except
+//               if carddav_name_only is true (see below).
+//
+// username:     CardDAV username to access the addressbook. Set this setting
+//               to '%u' to use the roundcube username.
+//               In case one uses an email address as username there is the
+//               additional option to choose '%l', which will only use the
+//               local part of the username (eg: user.name@example.com will
+//               become user.name).
+//               Also, %d is available to get only the domain part of the
+//               username (eg: user.name@example.com will become example.com).
+//
+// password:     CardDAV password to access the addressbook. Set this setting
+//               to '%p' to use the roundcube password. The password will not
+//               be stored in the database when using %p.
+//
+// url:          URL where to find the CardDAV addressbook(s). If the given URL
+//               refers directly to an addressbook, only this single
+//               addressbook will be added. If the URL points somewhere in the
+//               CardDAV space, but _not_ to the location of a particular
+//               addressbook, the server will be queried for the available
+//               addressbooks and all of them will be added. You can use %u
+//               within the URL as a placeholder for the CardDAV username.
+//               '%l' works the same way as it does for the username field.
+//
+// The following parameters are OPTIONAL and need to be specified only if the default
+// value is not acceptable.
+//
+// active:       If this parameter is false, the addressbook is not used by roundcube
+//               unless the user changes this setting.
+//               Default: true
+//
+// carddav_name_only:
+//               If this parameter is true, only the server provided displayname
+//               is used for addressbooks created from this preset, except if
+//               the server does not provide a display name.
+//               Default: false
+//
+// readonly:     If this parameter is true, the addressbook will only be
+//               accessible in read-only mode, i.e., the user will not be able
+//               to add, modify or delete contacts in the addressbook.
+//               Default: false
+//
+// refresh_time: Time interval for that cached versions of the addressbook
+//               entries should be used, in hours. After this time interval has
+//               passed since the last pull from the server, it will be
+//               refreshed when the addressbook is accessed the next time.
+//               Default: 01:00:00
+//
+// fixed:        Array of parameter keys that must not be changed by the user.
+//               Note that only fixed parameters will be automatically updated
+//               for existing addressbooks created from presets. Otherwise the
+//               user may already have changed the setting, and his change
+//               would be lost. You can add any of the above keys, but it the
+//               setting only affects parameters that can be changed via the
+//               settings pane (e.g., readonly cannot be changed by the user
+//               anyway). Still only parameters listed as fixed will
+//               automatically updated if the preset is changed.
+//               Default: empty, all settings modifiable by user
+//
+//               !!! WARNING: Only add 'url' to the list of fixed addressbooks
+//                if it _directly_ points to an address book collection.
+//                Otherwise, the plugin will initially lookup the URLs for the
+//                collections on the server, and at the next login overwrite it
+//                with the fixed value stored here. Therefore, if you change the
+//                URL, you have two options:
+//                1) If the new URL is a variation of the old one (e.g. hostname
+//                 change), you can run an SQL UPDATE query directly in the
+//                 database to adopt all addressbooks.
+//                2) If the new URL is not easily derivable from the old one,
+//                 change the key of the preset and change the URL. Addressbooks
+//                 belonging to the old preset will be deleted upon the next
+//                 login of the user and freshly created.
+//
+// hide:         Whether this preset should be hidden from the CalDAV listing
+//               on the preferences page.
+
+
+// How Preset Updates work
+//
+// Preset addressbooks are created for a user as she logs in.
+
+//// ** ADDRESSBOOK PRESETS - EXAMPLE: Two Addressbook Presets
+
+//// Preset 1: Personal
+/*
+$prefs['Personal'] = array(
+	// required attributes
+	'name'         =>  'Personal',
+	// will be substituted for the roundcube username
+	'username'     =>  '%u', 
+	// will be substituted for the roundcube password
+	'password'     =>  '%p',
+	// %u will be substituted for the CardDAV username
+	'url'          =>  'https://ical.example.org/caldav.php/%u/Personal',
+
+	'active'       =>  true,
+	'readonly'     =>  false,
+	'refresh_time' => '02:00:00',
+
+	'fixed'        =>  array( 'username' ),
+	'hide'        =>  false,
+);
+*/
+
+//// Preset 2: Corporate
+/*
+$prefs['Work'] = array(
+	'name'         =>  'Corporate',
+	'username'     =>  'CorpUser',
+	'password'     =>  'C0rpPasswo2d',
+	'url'          =>  'https://ical.example.org/caldav.php/%u/Corporate',
+
+	'fixed'        =>  array( 'name', 'username', 'password' ),
+	'hide'        =>  true,
+);
+*/

--- a/roles/webmail/files/var_www_roundcube_plugins_managesieve_config.inc.php
+++ b/roles/webmail/files/var_www_roundcube_plugins_managesieve_config.inc.php
@@ -1,0 +1,100 @@
+<?php
+
+// managesieve server port. When empty the port will be determined automatically
+// using getservbyname() function, with 4190 as a fallback.
+$config['managesieve_port'] = null;
+
+// managesieve server address, default is localhost.
+// Replacement variables supported in host name:
+// %h - user's IMAP hostname
+// %n - http hostname ($_SERVER['SERVER_NAME'])
+// %d - domain (http hostname without the first part)
+// For example %n = mail.domain.tld, %d = domain.tld
+$config['managesieve_host'] = 'localhost';
+
+// authentication method. Can be CRAM-MD5, DIGEST-MD5, PLAIN, LOGIN, EXTERNAL
+// or none. Optional, defaults to best method supported by server.
+$config['managesieve_auth_type'] = null;
+
+// Optional managesieve authentication identifier to be used as authorization proxy.
+// Authenticate as a different user but act on behalf of the logged in user.
+// Works with PLAIN and DIGEST-MD5 auth.
+$config['managesieve_auth_cid'] = null;
+
+// Optional managesieve authentication password to be used for imap_auth_cid
+$config['managesieve_auth_pw'] = null;
+
+// use or not TLS for managesieve server connection
+// Note: tls:// prefix in managesieve_host is also supported
+$config['managesieve_usetls'] = false;
+
+// Connection scket context options
+// See http://php.net/manual/en/context.ssl.php
+// The example below enables server certificate validation
+//$config['managesieve_conn_options'] = array(
+//  'ssl'         => array(
+//     'verify_peer'  => true,
+//     'verify_depth' => 3,
+//     'cafile'       => '/etc/openssl/certs/ca.crt',
+//   ),
+// );
+$config['managesieve_conn_options'] = null;
+
+// default contents of filters script (eg. default spam filter)
+$config['managesieve_default'] = '/etc/dovecot/sieve/global';
+
+// The name of the script which will be used when there's no user script
+$config['managesieve_script_name'] = 'managesieve';
+
+// Sieve RFC says that we should use UTF-8 endcoding for mailbox names,
+// but some implementations does not covert UTF-8 to modified UTF-7.
+// Defaults to UTF7-IMAP
+$config['managesieve_mbox_encoding'] = 'UTF-8';
+
+// I need this because my dovecot (with listescape plugin) uses
+// ':' delimiter, but creates folders with dot delimiter
+$config['managesieve_replace_delimiter'] = '';
+
+// disabled sieve extensions (body, copy, date, editheader, encoded-character,
+// envelope, environment, ereject, fileinto, ihave, imap4flags, index,
+// mailbox, mboxmetadata, regex, reject, relational, servermetadata,
+// spamtest, spamtestplus, subaddress, vacation, variables, virustest, etc.
+// Note: not all extensions are implemented
+$config['managesieve_disabled_extensions'] = array();
+
+// Enables debugging of conversation with sieve server. Logs it into <log_dir>/sieve
+$config['managesieve_debug'] = false;
+
+// Enables features described in http://wiki.kolab.org/KEP:14
+$config['managesieve_kolab_master'] = false;
+
+// Script name extension used for scripts including. Dovecot uses '.sieve',
+// Cyrus uses '.siv'. Doesn't matter if you have managesieve_kolab_master disabled.
+$config['managesieve_filename_extension'] = '.sieve';
+
+// List of reserved script names (without extension).
+// Scripts listed here will be not presented to the user.
+$config['managesieve_filename_exceptions'] = array();
+
+// List of domains limiting destination emails in redirect action
+// If not empty, user will need to select domain from a list
+$config['managesieve_domains'] = array();
+
+// Enables separate management interface for vacation responses (out-of-office)
+// 0 - no separate section (default),
+// 1 - add Vacation section,
+// 2 - add Vacation section, but hide Filters section
+$config['managesieve_vacation'] = 0;
+
+// Default vacation interval (in days).
+// Note: If server supports vacation-seconds extension it is possible
+// to define interval in seconds here (as a string), e.g. "3600s".
+$config['managesieve_vacation_interval'] = 0;
+
+// Some servers require vacation :addresses to be filled with all
+// user addresses (aliases). This option enables automatic filling
+// of these on initial vacation form creation.
+$config['managesieve_vacation_addresses_init'] = false;
+
+// Supported methods of notify extension. Default: 'mailto'
+$config['managesieve_notify_methods'] = array('mailto');

--- a/roles/webmail/files/var_www_roundcube_plugins_managesieve_config.inc.php
+++ b/roles/webmail/files/var_www_roundcube_plugins_managesieve_config.inc.php
@@ -41,7 +41,7 @@ $config['managesieve_usetls'] = false;
 $config['managesieve_conn_options'] = null;
 
 // default contents of filters script (eg. default spam filter)
-$config['managesieve_default'] = '/etc/dovecot/sieve/global';
+$config['managesieve_default'] = '/var/www/roundcube/config/global.sieve';
 
 // The name of the script which will be used when there's no user script
 $config['managesieve_script_name'] = 'managesieve';

--- a/roles/webmail/files/var_www_roundcube_plugins_twofactor_gauthenticator_config.inc.php
+++ b/roles/webmail/files/var_www_roundcube_plugins_twofactor_gauthenticator_config.inc.php
@@ -1,0 +1,7 @@
+<?php
+// if true ALL users must have 2-steps active
+$rcmail_config['force_enrollment_users'] = false;
+
+// whitelist, CIDR format available
+// NOTE: we need to use .0 IP to define LAN because the class CIDR have a issue about that (we can't use 129.168.1.2/24, for example)
+$rcmail_config['whitelist'] = array('192.168.1.0/24', '::1', '192.168.0.9');

--- a/roles/webmail/tasks/main.yml
+++ b/roles/webmail/tasks/main.yml
@@ -1,0 +1,1 @@
+- include: roundcube.yml tags=roundcube

--- a/roles/webmail/tasks/roundcube.yml
+++ b/roles/webmail/tasks/roundcube.yml
@@ -28,9 +28,12 @@
   get_url: url=https://getcomposer.org/installer
            dest=/tmp/composer-installer
 
-- name: Copy compose configuration
-  command: creates="/var/www/roundcube/composer.json" mv /var/www/roundcube/composer.json-dist /var/www/roundcube/composer.json
-  
+- name: Copy composer configuration
+  copy: src=var_www_roundcube_composer.json dest=/var/www/roundcube/composer.json
+    owner=root
+    group=www-data
+    mode=0644
+
 - name: Install Composer
   command: php /tmp/composer-installer
            chdir=/root
@@ -58,6 +61,27 @@
 
 - name: Make roundcube directory accessible to web server
   file: path=/var/www/roundcube group=www-data recurse=yes state=directory
+
+- name: Install sieve plugin configuration
+  copy: src=var_www_roundcube_plugins_managesieve_config.inc.php
+    dest=/var/www/roundcube/plugins/managesieve/config.inc.php
+    owner=root
+    group=www-data
+    mode=0644
+
+- name: Install carddav plugin configuration
+  copy: src=var_www_roundcube_plugins_carddav_config.inc.php
+    dest=/var/www/roundcube/plugins/carddav/config.inc.php
+    owner=root
+    group=www-data
+    mode=0644
+
+- name: Install Google 2-factor authentication plugin configuration
+  copy: src=var_www_roundcube_plugins_twofactor_gauthenticator_config.inc.php
+    dest=/var/www/roundcube/plugins/twofactor_gauthenticator/config.inc.php
+    owner=root
+    group=www-data
+    mode=0644
 
 - name: Configure Apache for Roundcube
   template: src=etc_apache2_sites-available_roundcube.j2

--- a/roles/webmail/tasks/roundcube.yml
+++ b/roles/webmail/tasks/roundcube.yml
@@ -69,6 +69,13 @@
     group=www-data
     mode=0644
 
+- name: Install global sieve
+  copy: src=var_www_roundcube_config_global.sieve
+    dest=/var/www/roundcube/config/global.sieve
+    owner=root
+    group=www-data
+    mode=0644
+
 - name: Install carddav plugin configuration
   copy: src=var_www_roundcube_plugins_carddav_config.inc.php
     dest=/var/www/roundcube/plugins/carddav/config.inc.php

--- a/roles/webmail/tasks/roundcube.yml
+++ b/roles/webmail/tasks/roundcube.yml
@@ -1,0 +1,69 @@
+- name: Determine whether roundcube is configured
+  stat: path=/var/www/roundcube/config.inc.php
+  register: roundcube_config
+
+- name: Install roundcube dependencies
+  apt: pkg={{ item }} state=present
+  with_items:
+    - php5
+    - php5-sqlite
+    - php5-mcrypt
+    - php5-gd
+    - php5-pspell
+    - php5-intl
+    - php5-curl
+    - aspell
+    - aspell-en
+  tags:
+    - dependencies
+
+- name: Clone roundcube
+  git: repo=https://github.com/roundcube/roundcubemail.git
+       dest=/var/www/roundcube
+       version={{ webmail_version }}
+       update=no
+       accept_hostkey=yes
+
+- name: Get Composer installer
+  get_url: url=https://getcomposer.org/installer
+           dest=/tmp/composer-installer
+
+- name: Copy compose configuration
+  command: creates="/var/www/roundcube/composer.json" mv /var/www/roundcube/composer.json-dist /var/www/roundcube/composer.json
+  
+- name: Install Composer
+  command: php /tmp/composer-installer
+           chdir=/root
+           creates=/root/composer.phar
+
+- name: Initialize composer
+  command: php /root/composer.phar install --no-dev
+           chdir=/var/www/roundcube
+           creates=/var/www/roundcube/vendor/autoload.php
+
+- name: Remove installer directory
+  file: path=/var/www/roundcube/installer state=absent
+
+- name: Install Roundcube configuration
+  template: src=var_www_roundcube_config_config.inc.j2 dest=/var/www/roundcube/config/config.inc.php
+
+- name: Create db directory
+  file: path=/decrypted/roundcube mode=0775 state=directory
+
+- name: Make logs and temp directories writable by web server
+  file: path=/var/www/roundcube/{{ item }} mode=0775 state=directory
+  with_items:
+    - temp
+    - logs
+
+- name: Make roundcube directory accessible to web server
+  file: path=/var/www/roundcube group=www-data recurse=yes state=directory
+
+- name: Configure Apache for Roundcube
+  template: src=etc_apache2_sites-available_roundcube.j2
+    dest=/etc/apache2/sites-available/roundcube.conf
+    group=root owner=root force=yes
+
+- name: Enable Roundcube site
+  command: a2ensite roundcube.conf creates=/etc/apache2/sites-enabled/roundcube.conf
+  notify: restart apache

--- a/roles/webmail/templates/etc_apache2_sites-available_roundcube.j2
+++ b/roles/webmail/templates/etc_apache2_sites-available_roundcube.j2
@@ -1,0 +1,38 @@
+<VirtualHost *:80>
+    ServerName {{ webmail_domain }}
+
+    Redirect permanent / https://{{ webmail_domain }}/
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName {{ webmail_domain }}
+    SSLEngine On
+
+    DocumentRoot            /var/www/roundcube
+    Options                 -Indexes
+
+    <Directory /var/www/roundcube>
+        AllowOverride All
+        Require all granted
+        DirectoryIndex index.php
+    </Directory>
+
+    <Directory /opt/roundcube/config>
+        AllowOverride None
+	Require all denied
+    </Directory>
+
+    <Directory /opt/roundcube/temp>
+        AllowOverride None
+	Require all denied
+    </Directory>
+
+    <Directory /opt/roundcube/logs>
+        AllowOverride None
+	Require all denied
+    </Directory>
+
+    LogLevel		    warn
+    ErrorLog                /var/log/apache2/roundcube.info-error_log
+    CustomLog               /var/log/apache2/roundcube.info-access_log common
+</VirtualHost>

--- a/roles/webmail/templates/var_www_roundcube_config_config.inc.j2
+++ b/roles/webmail/templates/var_www_roundcube_config_config.inc.j2
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ +-----------------------------------------------------------------------+
+ | Local configuration for the Roundcube Webmail installation.           |
+ |                                                                       |
+ | This is a sample configuration file only containing the minimum       |
+ | setup required for a functional installation. Copy more options       |
+ | from defaults.inc.php to this file to override the defaults.          |
+ |                                                                       |
+ | This file is part of the Roundcube Webmail client                     |
+ | Copyright (C) 2005-2013, The Roundcube Dev Team                       |
+ |                                                                       |
+ | Licensed under the GNU General Public License version 3 or            |
+ | any later version with exceptions for skins & plugins.                |
+ | See the README file for a full license statement.                     |
+ +-----------------------------------------------------------------------+
+*/
+
+$config = array();
+
+// Database connection string (DSN) for read+write operations
+// Format (compatible with PEAR MDB2): db_provider://user:password@host/database
+// Currently supported db_providers: mysql, pgsql, sqlite, mssql, sqlsrv, oracle
+// For examples see http://pear.php.net/manual/en/package.database.mdb2.intro-dsn.php
+// NOTE: for SQLite use absolute path (Linux): 'sqlite:////full/path/to/sqlite.db?mode=0646'
+//       or (Windows): 'sqlite:///C:/full/path/to/sqlite.db'
+$config['db_dsnw'] = 'mysql://roundcube:pass@localhost/roundcubemail';
+
+// The mail host chosen to perform the log-in.
+// Leave blank to show a textbox at login, give a list of hosts
+// to display a pulldown menu or set one host as string.
+// To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://
+// Supported replacement variables:
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
+// %s - domain name after the '@' from e-mail address provided at login screen
+// For example %n = mail.domain.tld, %t = domain.tld
+$config['default_host'] = 'localhost';
+
+// SMTP server host (for sending mails).
+// To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://
+// If left blank, the PHP mail() function is used
+// Supported replacement variables:
+// %h - user's IMAP hostname
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
+// %z - IMAP domain (IMAP hostname without the first part)
+// For example %n = mail.domain.tld, %t = domain.tld
+$config['smtp_server'] = '';
+
+// SMTP port (default is 25; use 587 for STARTTLS or 465 for the
+// deprecated SSL over SMTP (aka SMTPS))
+$config['smtp_port'] = 25;
+
+// SMTP username (if required) if you use %u as the username Roundcube
+// will use the current username for login
+$config['smtp_user'] = '';
+
+// SMTP password (if required) if you use %p as the password Roundcube
+// will use the current user's password for login
+$config['smtp_pass'] = '';
+
+// provide an URL where a user can get support for this Roundcube installation
+// PLEASE DO NOT LINK TO THE ROUNDCUBE.NET WEBSITE HERE!
+$config['support_url'] = '';
+
+// Name your service. This is displayed on the login screen and in the window title
+$config['product_name'] = 'Roundcube Webmail';
+
+// this key is used to encrypt the users imap password which is stored
+// in the session record (and the client cookie if remember password is enabled).
+// please provide a string of exactly 24 chars.
+// YOUR KEY MUST BE DIFFERENT THAN THE SAMPLE VALUE FOR SECURITY REASONS
+$config['des_key'] = 'rcmail-!24ByteDESkey*Str';
+
+// List of active plugins (in plugins/ directory)
+$config['plugins'] = array(
+    'archive',
+    'zipdownload',
+);
+
+// skin name: folder from skins/
+$config['skin'] = 'larry';

--- a/roles/webmail/templates/var_www_roundcube_config_config.inc.j2
+++ b/roles/webmail/templates/var_www_roundcube_config_config.inc.j2
@@ -25,7 +25,7 @@ $config = array();
 // For examples see http://pear.php.net/manual/en/package.database.mdb2.intro-dsn.php
 // NOTE: for SQLite use absolute path (Linux): 'sqlite:////full/path/to/sqlite.db?mode=0646'
 //       or (Windows): 'sqlite:///C:/full/path/to/sqlite.db'
-$config['db_dsnw'] = 'mysql://roundcube:pass@localhost/roundcubemail';
+$config['db_dsnw'] = 'sqlite:////decrypted/roundcube/sqlite.db?mode=0664';
 
 // The mail host chosen to perform the log-in.
 // Leave blank to show a textbox at login, give a list of hosts
@@ -37,7 +37,7 @@ $config['db_dsnw'] = 'mysql://roundcube:pass@localhost/roundcubemail';
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %s - domain name after the '@' from e-mail address provided at login screen
 // For example %n = mail.domain.tld, %t = domain.tld
-$config['default_host'] = 'localhost';
+$config['default_host'] = 'ssl://{{ webmail_domain }}:993';
 
 // SMTP server host (for sending mails).
 // To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://
@@ -49,19 +49,19 @@ $config['default_host'] = 'localhost';
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
 // For example %n = mail.domain.tld, %t = domain.tld
-$config['smtp_server'] = '';
+$config['smtp_server'] = 'localhost';
 
 // SMTP port (default is 25; use 587 for STARTTLS or 465 for the
 // deprecated SSL over SMTP (aka SMTPS))
-$config['smtp_port'] = 25;
+$config['smtp_port'] = 465;
 
 // SMTP username (if required) if you use %u as the username Roundcube
 // will use the current username for login
-$config['smtp_user'] = '';
+$config['smtp_user'] = '%u';
 
 // SMTP password (if required) if you use %p as the password Roundcube
 // will use the current user's password for login
-$config['smtp_pass'] = '';
+$config['smtp_pass'] = '%p';
 
 // provide an URL where a user can get support for this Roundcube installation
 // PLEASE DO NOT LINK TO THE ROUNDCUBE.NET WEBSITE HERE!
@@ -74,7 +74,7 @@ $config['product_name'] = 'Roundcube Webmail';
 // in the session record (and the client cookie if remember password is enabled).
 // please provide a string of exactly 24 chars.
 // YOUR KEY MUST BE DIFFERENT THAN THE SAMPLE VALUE FOR SECURITY REASONS
-$config['des_key'] = 'rcmail-!24ByteDESkey*Str';
+$config['des_key'] = 'fwef42cna12wefew9fewfmac';
 
 // List of active plugins (in plugins/ directory)
 $config['plugins'] = array(

--- a/roles/webmail/templates/var_www_roundcube_config_config.inc.j2
+++ b/roles/webmail/templates/var_www_roundcube_config_config.inc.j2
@@ -80,6 +80,9 @@ $config['des_key'] = 'fwef42cna12wefew9fewfmac';
 $config['plugins'] = array(
     'archive',
     'zipdownload',
+    'managesieve',
+    'twofactor_gauthenticator',
+    'carddav',
 );
 
 // skin name: folder from skins/

--- a/site.yml
+++ b/site.yml
@@ -9,6 +9,7 @@
   roles:
     - common
     - mailserver
+    - webmail
     - blog
     - ircbouncer
     - xmpp


### PR DESCRIPTION
This PR reinstates the webmail role lost when we moved to Jessie.  It installs Roundcube from source using sqlite3 as the database backend.  The `carddav`, `managesieve`, and `twofactor_gauthentication` plugins are carried forward using the plugin management system that the Roundcube team has implemented using PHP composer.