### PR TITLE
Force git pull when pulling wallabag

### DIFF
--- a/roles/readlater/tasks/wallabag.yml
+++ b/roles/readlater/tasks/wallabag.yml
@@ -4,6 +4,7 @@
 
 - name: Clone wallabag
   git: repo=https://github.com/wallabag/wallabag.git
+       force=yes
        dest=/var/www/wallabag
        version={{ wallabag_version }}
        accept_hostkey=yes


### PR DESCRIPTION
In few instances I had situation where certain files were removed from wallabag installation (probably by wallabag itself, or by sovereign) which resulted in process breaking due git refusing to pull updates into repo with uncommited changes. Force=yes should get around it.