### PR TITLE
Set default locales in order to start postgresql

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -59,6 +59,9 @@
 - name: Set decrypted directory permissions
   file: state=directory path=/decrypted group=mail mode=0775
 
+- name: "Configure locales"
+  shell: export LANGUAGE="en_US.UTF-8" && echo 'LANGUAGE="en_US.UTF-8"' >> /etc/default/locale && echo 'LC_ALL="en_US.UTF-8"' >> /etc/default/locale
+
 - include: encfs.yml tags=encfs
 - include: users.yml tags=users
 - include: apache.yml tags=apache


### PR DESCRIPTION
Hi,
I had a trouble with installation.
![selection_069](https://cloud.githubusercontent.com/assets/2339101/19840450/d1dd7b68-9efe-11e6-8b0e-0fa3b3077042.png)

It appeared, that postgresql needed correct locale to be exported. This is very simple and naive fix. However, it works.