### PR TITLE
Fix bare variable depreciation

### DIFF
--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -23,11 +23,11 @@
 
 - name: Ensure mail domain directories are in place
   file: state=directory path=/decrypted/{{ item.name }} owner=vmail group=dovecot mode=0770
-  with_items: mail_virtual_domains
+  with_items: '{{ mail_virtual_domains }}'
 
 - name: Ensure mail directories are in place
   file: state=directory path=/decrypted/{{ item.domain }}/{{ item.account }} owner=vmail group=dovecot
-  with_items: mail_virtual_users
+  with_items: '{{ mail_virtual_users }}'
 
 - name: Copy dovecot.conf into place
   copy: src=etc_dovecot_dovecot.conf dest=/etc/dovecot/dovecot.conf


### PR DESCRIPTION
Newer versions of Ansible complain when using bare variables like `mail_virtual_users` and prefer the newer `'{{ mail_virtual_users }}'` syntax:

<img width="994" alt="depreciation" src="https://cloud.githubusercontent.com/assets/68112/20024752/c65d958c-a2e8-11e6-87ea-88371b820c5b.png">

This commit fixes two of those old style bare variables: the `mail_virtual_domains` and `mail_virtual_users` one. There might be more but I did not run the full playbook.

Seen in Ansible version 2.1.2.0.