### PR TITLE
Fix mail_virtual_domains config reading in opendkim

### DIFF
--- a/roles/mailserver/tasks/opendkim.yml
+++ b/roles/mailserver/tasks/opendkim.yml
@@ -14,11 +14,11 @@
 
 - name: Create OpenDKIM key directories
   file: state=directory path=/etc/opendkim/keys/{{ item.name }} group=opendkim owner=opendkim
-  with_items: mail_virtual_domains
+  with_items: "{{ mail_virtual_domains }}"
 
 - name: Generate OpenDKIM keys
   command: opendkim-genkey -r -d {{ item.name }} -D /etc/opendkim/keys/{{ item.name }}/ creates=/etc/opendkim/keys/{{ item.name }}/default.private
-  with_items: mail_virtual_domains
+  with_items: "{{ mail_virtual_domains }}"
 
 - name: Put opendkim.conf into place
   copy: src=etc_opendkim.conf dest=/etc/opendkim.conf owner=opendkim group=opendkim


### PR DESCRIPTION
without this change it fails on ansible(2.2.0.0) with the following message:

    TASK [mailserver : Generate OpenDKIM keys] *************************************
    fatal: [sovereign.host]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'unicode object' has no attribute 'name'\n\nThe error appears to have been in '/Users/nfedyashev/Projects/sovereign/roles/mailserver/tasks/opendkim.yml': line 19, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Generate OpenDKIM keys\n  ^ here\n"}