### PR TITLE
Enable ownCloud virtual host automatically

### DIFF
--- a/roles/owncloud/tasks/owncloud.yml
+++ b/roles/owncloud/tasks/owncloud.yml
@@ -43,5 +43,9 @@
   template: src=etc_apache2_sites-available_owncloud.j2 dest=/etc/apache2/sites-available/owncloud.conf group=root
   notify: restart apache
 
+- name: Enable ownCloud site
+  command: a2ensite owncloud.conf creates=/etc/apache2/sites-enabled/owncloud.conf
+  notify: restart apache
+
 - name: Install ownCloud cronjob
   cron: name="ownCloud" user="www-data" minute="*/5" job="php -f /var/www/owncloud/cron.php > /dev/null"


### PR DESCRIPTION
Just noticed that owncloud playbook does not enables itself as apache virtual host. This is a bit surprising because roundcube and selfoss activates themselves just fine. This PR fixes it.

`roles/webmail/tasks/roundcube.yml` was used as inspiration for this PR.