### PR TITLE
Syntax fix in vpn and xmpp tasks.

### DIFF
--- a/roles/vpn/tasks/openvpn.yml
+++ b/roles/vpn/tasks/openvpn.yml
@@ -21,13 +21,13 @@
 
 - name: Create directories for clients
   file: path={{ openvpn_path}}/{{ item }} state=directory
-  with_items: openvpn_clients
+  with_items: "{{ openvpn_clients }}"
 
 - name: Generate RSA keys for the clients
   command: openssl genrsa -out client.key {{ openvpn_key_size }}
            chdir={{ openvpn_path }}/{{ item }}
            creates=client.key
-  with_items: openvpn_clients
+  with_items: "{{ openvpn_clients }}"
 
 - name: Set the proper permissions on all RSA keys
   file: path={{ openvpn_path }}
@@ -73,13 +73,13 @@
   command: openssl req -new -key client.key -out client.csr -subj "{{ openssl_request_subject }}/CN={{ item }}"
            chdir={{ openvpn_path }}/{{ item }}
            creates=client.csr
-  with_items: openvpn_clients
+  with_items: "{{ openvpn_clients }}"
 
 - name: Generate certificates for the clients
   command: openssl x509 -CA {{ openvpn_ca }}.crt -CAkey {{ openvpn_ca }}.key -CAcreateserial -req -days {{ openvpn_days_valid }} -in client.csr -out client.crt
            chdir={{ openvpn_path }}/{{ item }}
            creates=client.crt
-  with_items: openvpn_clients
+  with_items: "{{ openvpn_clients }}"
 
 - name: Generate HMAC firewall key
   command: openvpn --genkey --secret {{ openvpn_hmac_firewall }}
@@ -93,13 +93,13 @@
 - name: Register client certificate contents
   command: cat client.crt
            chdir={{ openvpn_path }}/{{ item }}
-  with_items: openvpn_clients
+  with_items: "{{ openvpn_clients }}"
   register: openvpn_client_certificates
 
 - name: Register client key contents
   command: cat client.key
            chdir={{ openvpn_path }}/{{ item }}
-  with_items: openvpn_clients
+  with_items: "{{ openvpn_clients }}"
   register: openvpn_client_keys
 
 - name: Register HMAC firewall contents
@@ -111,9 +111,9 @@
   template: src=client.cnf.j2
             dest={{ openvpn_path }}/{{ item[0] }}/{{ openvpn_server }}.ovpn
   with_together:
-    - openvpn_clients
-    - openvpn_client_certificates.results
-    - openvpn_client_keys.results
+    - "{{ openvpn_clients }}"
+    - "{{ openvpn_client_certificates.results }}"
+    - "{{ openvpn_client_keys.results }}"
 
 - name: Generate Diffie-Hellman parameters (this will take a while)
   command: openssl dhparam -out {{ openvpn_dhparam }} {{ openvpn_key_size }}

--- a/roles/xmpp/tasks/prosody.yml
+++ b/roles/xmpp/tasks/prosody.yml
@@ -28,7 +28,7 @@
 
 - name: Create Prosody accounts
   command: prosodyctl register {{ item.name }} {{ prosody_virtual_domain }} "{{ item.password }}"
-  with_items: prosody_accounts
+  with_items: "{{ prosody_accounts }}"
 
 - name: Set firewall rules for Prosody
   ufw: rule=allow port={{ item }} proto=tcp


### PR DESCRIPTION
This pull is meant to address issues [624](https://github.com/sovereign/sovereign/issues/624) and [629](https://github.com/sovereign/sovereign/issues/629). List variables should be referenced in the form `with_items: "{{ somelist }}"`, according the [ansible docs](https://docs.ansible.com/ansible/playbooks_loops.html).