### PR TITLE
Ensure en_US.UTF-8 locale is present

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -59,6 +59,11 @@
 - name: Set decrypted directory permissions
   file: state=directory path=/decrypted group=mail mode=0775
 
+- name: Ensure locale en_US.UTF-8 locale is present
+  locale_gen:
+    name: en_US.UTF-8
+    state: present
+
 - include: encfs.yml tags=encfs
 - include: users.yml tags=users
 - include: apache.yml tags=apache


### PR DESCRIPTION
I was testing mosh and could not get it to work as my vps did not have the required local. This PR ensures en_US.UTF-8 is present.