### PR TITLE
Use php* packages rather than php5* for packages on Ubuntu

### DIFF
--- a/roles/news/tasks/selfoss.yml
+++ b/roles/news/tasks/selfoss.yml
@@ -21,9 +21,9 @@
 - name: Install selfoss dependencies
   apt: pkg={{ item }} state=present
   with_items:
-    - php5
-    - php5-pgsql
-    - php5-gd
+    - "{{ (ansible_distribution == 'Ubuntu') | ternary('php', 'php5') }}"
+    - "{{ (ansible_distribution == 'Ubuntu') | ternary('php-pgsql', 'php5-pgsql') }}"
+    - "{{ (ansible_distribution == 'Ubuntu') | ternary('php-gd', 'php5-gd') }}"
   tags:
     - dependencies
 
@@ -62,7 +62,7 @@
   notify: restart apache
 
 - name: Install selfoss cronjob
-  cron: name="selfoss" user="www-data" minute="*/5" job="curl --silent --show-error -k 'https://{{ selfoss_domain }}/update' > /dev/null"
+  cron: name="selfoss" user="www-data" minute="*/5" job="php /var/www/selfoss/cliupdate.php"
 
 - name: Configure selfoss logrotate
   copy: src=etc_logrotate_selfoss dest=/etc/logrotate.d/selfoss owner=root group=root mode=0644


### PR DESCRIPTION
Also invokes the update PHP file, rather that the HTTP endpoint (which is secured and therefore cannot be invoked this way).