### PR TITLE
Fix cgit

### DIFF
--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,3 +1,3 @@
-cgit_version: 0.12
+cgit_version: 1.1
 cgit_domain: "git.{{ domain }}"
 gitolite_version: 3.6.4

--- a/roles/git/tasks/cgit.yml
+++ b/roles/git/tasks/cgit.yml
@@ -4,17 +4,9 @@
   with_items:
     - groff
     - libssl-dev
-    - python-pip
     - python3-pip
   tags:
     - dependencies
-
-- name: Install cgit pip dependencies
-  pip: name={{ item }}
-  with_items:
-    - docutils
-    - pygments
-    - markdown
 
 - name: Install cgit pip dependencies python 3
   pip:

--- a/roles/git/tasks/cgit.yml
+++ b/roles/git/tasks/cgit.yml
@@ -5,6 +5,7 @@
     - groff
     - libssl-dev
     - python-pip
+    - python3-pip
   tags:
     - dependencies
 
@@ -13,6 +14,16 @@
   with_items:
     - docutils
     - pygments
+    - markdown
+
+- name: Install cgit pip dependencies python 3
+  pip:
+    name: "{{ item }}"
+    executable: pip3
+  with_items:
+    - docutils
+    - pygments
+    - markdown
 
 - name: Download cgit release
   get_url: url=http://git.zx2c4.com/cgit/snapshot/cgit-{{ cgit_version }}.tar.xz

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,2 +1,4 @@
-- include: gitolite.yml tags=gitolite
-- include: cgit.yml tags=cgit
+- include: gitolite.yml
+  tags: gitolite
+- include: cgit.yml
+  tags: cgit


### PR DESCRIPTION
I was testing the git hosting role, and although the cgit website displayed neither the about page of a repository displayed any content nor was it possible to view the content of any file.

- The first problem originated because my readme file is README.md a markdown file. That dependency is not installed with pip.
- Second problem is that source files are parsed by the syntax highlighter. That script in cgit enforces the use of python3 but the pygments dependency is installed with the system pip which in debian jessy is still python2, thus pygments was not available for use in the python3 interpreter. I have added a Python3 pip and install pip3 dependencies for it

I was also thinking it might be good to update cgit version to current 1.1. That version even enforces python3 in the markdown converter. That would allow to remove the pip2 install dependency that I for the moment have left in the role. Also I don't know how to force the install step once the version has been updated.