### PR TITLE
fix pgsql connection issues from missing quotes in selfoss config file

### DIFF
--- a/roles/news/templates/var_www_selfoss_config.ini.j2
+++ b/roles/news/templates/var_www_selfoss_config.ini.j2
@@ -1,9 +1,10 @@
 ; see https://github.com/SSilence/selfoss/wiki/Configuration for more information about the configuration parameters
 [globals]
 db_type=pgsql
-db_database={{selfoss_db_database}}
-db_username={{selfoss_db_username}}
-db_password={{selfoss_db_password}}
+db_host=127.0.0.1
+db_database="{{selfoss_db_database}}"
+db_username="{{selfoss_db_username}}"
+db_password="{{selfoss_db_password}}"
 db_port=5432
 db_prefix=
 logger_level=DEBUG


### PR DESCRIPTION
I found that some of the generated password characters can cause issues with selfoss connecting to the pgsql database, adding quotes in the config fixes this issue.  