### PR TITLE
Copy missing configuration file "20-imap.conf"

### DIFF
--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -59,6 +59,10 @@
   template: src=etc_dovecot_conf.d_15-lda.conf.j2 dest=/etc/dovecot/conf.d/15-lda.conf
   notify: restart dovecot
 
+- name: Template 20-imap.conf
+  template: src=etc_dovecot_conf.d_20-imap.conf.j2 dest=/etc/dovecot/conf.d/20-imap.conf
+  notify: restart dovecot
+
 - name: Template dovecot-sql.conf.ext
   template: src=etc_dovecot_dovecot-sql.conf.ext.j2 dest=/etc/dovecot/dovecot-sql.conf.ext
   notify: restart dovecot

--- a/roles/mailserver/templates/etc_dovecot_conf.d_20-imap.conf.j2
+++ b/roles/mailserver/templates/etc_dovecot_conf.d_20-imap.conf.j2
@@ -60,5 +60,5 @@ protocol imap {
 protocol lmtp {
   # Space separated list of plugins to load (default is global mail_plugins).
   mail_plugins = $mail_plugins sieve
-  postmaster_address = postmaster@{{domain}}
+  postmaster_address = postmaster@{{ domain }}
 }


### PR DESCRIPTION
I noticed that my Sieve filters were not being applied. The [issue](https://github.com/sovereign/sovereign/issues/685) reported by @bmiller59 pointed me to a `lmtp` section that was missing from the Dovecot configuration files.

Apparently the file containing the missing setting was already present in the repository, it was just not being transfered by the dovecot Ansible task. So I added `20-imap.conf` to the list of files to copy.