### PR TITLE
rmilter fails to start due to a missing trailing semicolon.

### DIFF
--- a/roles/mailserver/tasks/rspamd.yml
+++ b/roles/mailserver/tasks/rspamd.yml
@@ -38,7 +38,7 @@
   copy: src=etc_rmilter.conf.common dest=/etc/rmilter.conf.common
 
 - name: Configure rmilter socket
-  lineinfile: dest=/etc/rmilter.conf regexp=^bind_socket line="bind_socket = inet:9900@localhost"
+  lineinfile: dest=/etc/rmilter.conf regexp=^bind_socket line="bind_socket = inet:9900@localhost;"
 
 - name: Configure rmilter service
   copy: src=lib_systemd_system_rmilter.socket dest=/lib/systemd/system/rmilter.socket


### PR DESCRIPTION
there is a missing semicolon that causes rmilter not to start with error:
"config file parse error! line: 156, text: tempdir, reason: syntax error"

which, as expected is the following line