### PR TITLE
Upgrade Selfoss to version 2.17

### DIFF
--- a/roles/news/defaults/main.yml
+++ b/roles/news/defaults/main.yml
@@ -6,7 +6,7 @@ selfoss_domain: "news.{{ domain }}"
 selfoss_db_username: selfoss
 selfoss_db_password: "{{ lookup('password', secret + '/' + 'selfoss_db_password', length=32) }}"
 selfoss_db_database: selfoss
-selfoss_version: 2.16
+selfoss_version: 2.17
 
 selfoss_username: "{{ main_user_name }}"
 # this is the sha512 hash of the desired password

--- a/roles/news/tasks/selfoss.yml
+++ b/roles/news/tasks/selfoss.yml
@@ -1,3 +1,12 @@
+- name: Install selfoss dependencies
+  apt: pkg={{ item }} state=present
+  with_items:
+    - php5
+    - php5-pgsql
+    - php5-gd
+  tags:
+    - dependencies
+
 - name: Clone Selfoss
   git: repo=https://github.com/SSilence/selfoss.git
        dest=/var/www/selfoss
@@ -6,6 +15,19 @@
 
 - name: Set selfoss ownership
   action: file owner=root group=www-data path=/var/www/selfoss recurse=yes state=directory
+
+- name: Get Composer installer
+  get_url: url=https://getcomposer.org/installer
+           dest=/tmp/composer-installer
+
+- name: Install Composer
+  command: php /tmp/composer-installer
+           chdir=/root
+           creates=/root/composer.phar
+
+- name: Run composer to install dependencies
+  command: php /root/composer.phar install
+           chdir=/var/www/selfoss
 
 # only data/cache, data/favicons, data/logs, data/thumbnails, data/sqlite public/ should be writeable by httpd
 - name: Set selfoss permission
@@ -17,15 +39,6 @@
     - data/thumbnails
     - data/sqlite
     - public
-
-- name: Install selfoss dependencies
-  apt: pkg={{ item }} state=present
-  with_items:
-    - php5
-    - php5-pgsql
-    - php5-gd
-  tags:
-    - dependencies
 
 - name: Create database user for selfoss
   postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ selfoss_db_username }} password="{{ selfoss_db_password }}" state=present


### PR DESCRIPTION
This picks up a variety of improvements but most importantly makes
selfoss [compatible with Apache
2.4](https://github.com/SSilence/selfoss/commit/8bc38c0820afb8697bb729d4dfd7165db376084a).

Selfoss uses composer to install dependencies starting with version
2.17.  Task list updated accordingly.