### PR TITLE
Install dovecot-antispam module

### DIFF
--- a/roles/mailserver/tasks/dovecot.yml
+++ b/roles/mailserver/tasks/dovecot.yml
@@ -7,6 +7,7 @@
     - dovecot-managesieved
     - dovecot-pgsql
     - dovecot-pop3d
+    - dovecot-antispam
   tags:
     - dependencies
 


### PR DESCRIPTION
Every time, after successfully by imap the connection would terminate with EOF and I would not get my email.

Reviewing the dovecot log there was this hint.
```
dovecot: imap: Fatal: Plugin 'antispam' not found from directory /usr/lib/dovecot/modules
```
After installing this module everything worked