### PR TITLE
Updating fail2ban jail list

### DIFF
--- a/roles/common/templates/etc_fail2ban_jail.local.j2
+++ b/roles/common/templates/etc_fail2ban_jail.local.j2
@@ -6,7 +6,7 @@ banaction = iptables-multiport
 action    = %(action_)s
 
 # JAILS
-[ssh]
+[sshd]
 enabled   = true
 maxretry  = 3
 
@@ -14,10 +14,40 @@ maxretry  = 3
 enabled   = true
 banaction = iptables-allports
 
-[ssh-ddos]
+[sshd-ddos]
 enabled   = true
 
-[apache]
+[apache-auth]
+enabled = true
+
+[apache-badbots]
+enabled = true
+
+[apache-botsearch]
+enabled = true
+
+[apache-common]
+enabled = true
+
+[apache-fakegooglebot]
+enabled = true
+
+[apache-modsecurity]
+enabled = true
+
+[apache-nohome]
+enabled = true
+
+[apache-noscript]
+enabled = true
+
+[apache-overflows]
+enabled = true
+
+[apache-pass]
+enabled = true
+
+[apache-shellshock]
 enabled = true
 
 [postfix]


### PR DESCRIPTION
This changes the list of jails used by fail2ban to match the names of the config files in /etc/fail2ban/filter.d