### PR TITLE
use mozilla ssh config on algorithms

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -15,9 +15,10 @@ encfs_password: "{{ lookup('password', secret + '/' + 'encfs_password', length=3
 letsencrypt_server: "https://acme-v01.api.letsencrypt.org/directory"
 
 # ssh
-kex_algorithms: "diffie-hellman-group-exchange-sha256"
-ciphers: "aes256-ctr,aes192-ctr,aes128-ctr"
-macs: "hmac-sha2-512,hmac-sha2-256,hmac-ripemd160"
+# Following https://infosec.mozilla.org/guidelines/openssh
+kex_algorithms: "curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
+ciphers: "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
+macs: "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com"
 
 # ntp
 ntp_servers:


### PR DESCRIPTION
Following the security recommendations from mozilla https://infosec.mozilla.org/guidelines/openssh
We should update our ssh config.