### PR TITLE
[Prosody] Deprecated mod_privacy in favor of blocklist

### DIFF
--- a/roles/xmpp/tasks/prosody.yml
+++ b/roles/xmpp/tasks/prosody.yml
@@ -26,7 +26,7 @@
   file: state=directory path=/decrypted/prosody owner=prosody group=prosody
 
 - name: Configure Prosody
-  template: src=prosody.cfg.lua.j2 dest=/etc/prosody/prosody.cfg.lua group=root owner=root
+  template: src=prosody.cfg.lua.j2 dest=/etc/prosody/prosody.cfg.lua group=prosody owner=prosody
   notify: restart prosody
 
 - name: Create Prosody accounts

--- a/roles/xmpp/templates/prosody.cfg.lua.j2
+++ b/roles/xmpp/templates/prosody.cfg.lua.j2
@@ -43,7 +43,7 @@ modules_enabled = {
 		"vcard"; -- Allow users to set vCards
 
 	-- These are commented by default as they have a performance impact
-		"privacy"; -- Support privacy lists
+                "blocklist"; -- Support blocking users
 		--"compression"; -- Stream compression (requires the lua-zlib package installed)
 
 	-- Nice to have


### PR DESCRIPTION
After upgrading my VPS prosody wouldn't start. Error log complained mod_privacy being deprecated. I updated that. Also configuration file needs to belong to prosody user, to start the service. 

mod_privacy info and deprecation notice
https://modules.prosody.im/mod_privacy_lists.html