### PR TITLE
Use correct certificate file in prosody

### DIFF
--- a/roles/xmpp/templates/prosody.cfg.lua.j2
+++ b/roles/xmpp/templates/prosody.cfg.lua.j2
@@ -87,7 +87,7 @@ allow_registration = false;
 -- to use SSL/TLS, you may comment or remove this
 ssl = {
 	key = "/etc/letsencrypt/live/{{ domain }}/privkey.pem";
-	certificate = "/etc/letsencrypt/live/{{ domain }}/cert.pem";
+	certificate = "/etc/letsencrypt/live/{{ domain }}/fullchain.pem";
 }
 
 -- Force clients to use encrypted connections? This option will


### PR DESCRIPTION
Prosody uses the `cert.pem` file which fails to verify on servers configured to check the certificate chain. Using the `fullchain.pem` file fixes the problem.