### PR TITLE
Update fail2ban configuration for newer versions

### DIFF
--- a/roles/common/templates/etc_fail2ban_jail.local.j2
+++ b/roles/common/templates/etc_fail2ban_jail.local.j2
@@ -6,7 +6,11 @@ banaction = iptables-multiport
 action    = %(action_)s
 
 # JAILS
+{% if ansible_distribution_release == "jessie" -%}
 [ssh]
+{% else -%}
+[sshd]
+{% endif -%}
 enabled   = true
 maxretry  = 3
 
@@ -14,10 +18,18 @@ maxretry  = 3
 enabled   = true
 banaction = iptables-allports
 
+{% if ansible_distribution_release == "jessie" -%}
 [ssh-ddos]
+{% else -%}
+[sshd-ddos]
+{% endif -%}
 enabled   = true
 
+{% if ansible_distribution_release == "jessie" -%}
 [apache]
+{% else -%}
+[apache-auth]
+{% endif -%}
 enabled = true
 
 [postfix]

--- a/roles/common/templates/etc_fail2ban_jail.local.j2
+++ b/roles/common/templates/etc_fail2ban_jail.local.j2
@@ -35,6 +35,9 @@ enabled = true
 [postfix]
 enabled  = true
 maxretry = 1
+{% if ansible_distribution_release != "jessie" -%}
+logpath  = /var/log/mail.log
+{% endif %}
 
 [dovecot-pop3imap]
 enabled = true


### PR DESCRIPTION
As noted in several other issues and pull requests (#652, #739, #740, #743, etc.), the current fail2ban configuration only works with version 0.8.x and not with later versions that ship with newer distribution versions.

Besides the changes in the jail names defined in `/etc/fail2ban/jail.conf` the log path for the postfix jail is also different (`/var/log/mail.warn` instead of `/var/log/mail.log`) in the default configuration of newer fail2ban versions.

The changes here are intended to be as limited as possible and leave `/etc/fail2ban/jail.local` unmodified on Debian Jessie. While enabling other apache jails is probably a good idea, that should be discussed separately.

Fixes #739. Closes #740.