### PR TITLE
Fix Vagrant environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory
 .vagrant/machines
-tests.pyc
+.vagrant/rgloader
+*.log
+*.pyc
+*.retry
 secret

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,12 +4,18 @@ Vagrant.configure('2') do |config|
   config.vm.hostname = 'sovereign.local'
   config.vm.network 'private_network', ip: '172.16.100.2'
 
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get install -y \
+      python \
+      python-apt
+  SHELL
+
   config.vm.provision :ansible do |ansible|
     ansible.playbook = 'site.yml'
     ansible.host_key_checking = false
     ansible.extra_vars = { ansible_ssh_user: 'vagrant', testing: true }
     ansible.groups = {
-      "testing" => ["jessie"]
+      "testing" => ["jessie", "xenial"]
     }
 
     # ansible.tags = ['blog']
@@ -36,11 +42,11 @@ Vagrant.configure('2') do |config|
 
   # Debian 8 64-bit (officially supported)
   config.vm.define 'jessie', primary: true do |jessie|
-    jessie.vm.box = 'box-cutter/debian8'
+    jessie.vm.box = 'debian/contrib-jessie64'
   end
 
   # Ubuntu 16.04 (LTS) 64-bit (currently unavailable)
   config.vm.define 'xenial', autostart: false do |xenial|
-    xenial.vm.box = 'box-cutter/ubuntu1604'
+    xenial.vm.box = 'ubuntu/xenial64'
   end
 end

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- debug:
+    msg: >-
+      OwnCloud is no longer supported on Debian jessie
+      https://github.com/sovereign/sovereign/issues/765
+  when: ansible_distribution_release == "jessie"
 
 - include: owncloud.yml tags=owncloud
   # https://github.com/sovereign/sovereign/issues/765

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -1,3 +1,5 @@
 ---
 
 - include: owncloud.yml tags=owncloud
+  # https://github.com/sovereign/sovereign/issues/765
+  when: ansible_distribution_release != "jessie"

--- a/roles/xmpp/tasks/prosody.yml
+++ b/roles/xmpp/tasks/prosody.yml
@@ -26,7 +26,7 @@
   file: state=directory path=/decrypted/prosody owner=prosody group=prosody
 
 - name: Configure Prosody
-  template: src=prosody.cfg.lua.j2 dest=/etc/prosody/prosody.cfg.lua group=root owner=root
+  template: src=prosody.cfg.lua.j2 dest=/etc/prosody/prosody.cfg.lua group=prosody owner=prosody
   notify: restart prosody
 
 - name: Create Prosody accounts

--- a/roles/xmpp/tasks/prosody.yml
+++ b/roles/xmpp/tasks/prosody.yml
@@ -26,7 +26,7 @@
   file: state=directory path=/decrypted/prosody owner=prosody group=prosody
 
 - name: Configure Prosody
-  template: src=prosody.cfg.lua.j2 dest=/etc/prosody/prosody.cfg.lua group=prosody owner=prosody
+  template: src=prosody.cfg.lua.j2 dest=/etc/prosody/prosody.cfg.lua group=prosody owner=root mode=0644
   notify: restart prosody
 
 - name: Create Prosody accounts


### PR DESCRIPTION
Fixes https://github.com/sovereign/sovereign/issues/765
Fixes https://github.com/sovereign/sovereign/issues/762

This updates the Vagrant boxes to use official Ubuntu/Debian boxes. I added a shell provisioner to add ansible dependencies (python and python-apt) which are not included in the boxes.

I ran into an error installing OwnCloud on jessie in that the deb repo is failing with a 404. I disabled the role for jessie because of that (#765). I left the owncloud test in tests.py because the test is still valid for other releases/distros, but it would be nice to move to a framework that would allow us more control over the tests running on different platforms, e.g. the test could be skipped only on jessie.

I also ran into an issue with the prosody notifier. Prosody fails to restart because it cannot read prosody.cfg.lua (permission denied) which is mentioned (https://github.com/sovereign/sovereign/issues/748#issuecomment-467603918) but there's no explicit issue for it.

