### PR TITLE
Fix ZNC password configuration

### DIFF
--- a/filter_plugins/password_hash.py
+++ b/filter_plugins/password_hash.py
@@ -20,15 +20,24 @@ def doveadm_pw_hash(password):
     check_lib()
     if type(password) is StrictUndefined:
         raise AnsibleUndefinedVariable('Please pass a string into this password_hash-based filter')
+    # We use the implicit 5000 rounds as per spec
     return passlib.hash.sha512_crypt.encrypt(password, rounds=5000)
 
+def sha256_hash(password):
+    check_lib()
+    if type(password) is StrictUndefined:
+        raise AnsibleUndefinedVariable('Please pass a string into this password_hash-based filter')
+    # We use the implicit 5000 rounds as per spec
+    return passlib.hash.sha256_crypt.encrypt(password, rounds=5000)
 
 def znc_pw_salt(password):
-    return doveadm_pw_hash(password).split("$")[0]
+    # Hash has looks like $5$salt$hash
+    return sha256_hash(password).split("$")[2]
 
 
 def znc_pw_hash(password):
-    return doveadm_pw_hash(password).split("$")[1]
+    # Hash has looks like $5$salt$hash
+    return sha256_hash(password).split("$")[3]
 
 
 class FilterModule(object):

--- a/test_filter_plugins.py
+++ b/test_filter_plugins.py
@@ -1,0 +1,38 @@
+import unittest
+import os.path
+import sys
+
+# Make filter_plugins available for import
+sys.path.append(os.path.join(os.path.dirname(__file__), 'filter_plugins'))
+
+from password_hash import doveadm_pw_hash, znc_pw_hash, znc_pw_salt
+
+
+class PasswordHashPluginTest(unittest.TestCase):
+    def test_doveadm_pw_hash(self):
+        """doveadm_pw_hash returns a SHA512 hash"""
+        hashed_password = doveadm_pw_hash('test-password')
+
+        assert hashed_password != None
+        self.assertEqual(type(hashed_password), str)
+        # Hash expected to be SHA512 (starting with $6$)
+        self.assertEqual(hashed_password[:3], '$6$')
+        self.assertEqual(len(hashed_password), 106)
+
+    def test_znc_pw_hash(self):
+        """znc_pw_hash returns only the hashed password component"""
+        hashed_password = znc_pw_hash('test-password')
+
+        assert hashed_password != None
+        self.assertEqual(type(hashed_password), str)
+        self.assertFalse('$' in hashed_password)
+        self.assertEqual(len(hashed_password), 43)
+
+    def test_znc_pw_salt(self):
+        """znc_pw_salt retruns only the salt of the hash"""
+        salt = znc_pw_salt('test-password')
+
+        assert salt != None
+        self.assertEqual(type(salt), str)
+        self.assertFalse('$' in salt)
+        self.assertEqual(len(salt), 16)

--- a/tests.py
+++ b/tests.py
@@ -148,7 +148,7 @@ class IRCTests(unittest.TestCase):
 
         # Check the encryption parameters
         cipher, version, bits = ssl_sock.cipher()
-        self.assertEquals(cipher, 'AES256-GCM-SHA384')
+        self.assertEquals(cipher, 'ECDHE-RSA-AES256-GCM-SHA384')
         self.assertEquals(version, 'TLSv1/SSLv3')
         self.assertEquals(bits, 256)
 


### PR DESCRIPTION
- Use sha256 hash function (ZNC does not support sha512)
- Add tests for the filter plugins

Fixes #490 

The ZNC test in test.py still doesn't work. It gets through the initial assertions, but fails when initiating the IRC connection. Should I comment out the assertions that aren't working?