### PR TITLE
Switch to ACMEv2 server for letsencrypt

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -12,7 +12,7 @@ encfs_password: "{{ lookup('password', secret + '/' + 'encfs_password', length=3
 
 
 # let's encrypt
-letsencrypt_server: "https://acme-v01.api.letsencrypt.org/directory"
+letsencrypt_server: "https://acme-v02.api.letsencrypt.org/directory"
 
 # ssh
 kex_algorithms: "diffie-hellman-group-exchange-sha256"


### PR DESCRIPTION
Closes #783

Simply updating the hostname seems to do the trick.