### PR TITLE
Bugfixes for issue #809

### DIFF
--- a/roles/blog/templates/etc_apache2_sites-available_blog.j2
+++ b/roles/blog/templates/etc_apache2_sites-available_blog.j2
@@ -12,8 +12,10 @@
     SSLEngine On
 
     DocumentRoot            "/var/www/{{ domain }}"
-    DirectoryIndex          index.html
-    Options                 -Indexes
+    <Location />
+        DirectoryIndex          index.html
+        Options                 -Indexes
+    </Location>
 
     HostnameLookups         Off
 </VirtualHost>

--- a/roles/common/tasks/apache.yml
+++ b/roles/common/tasks/apache.yml
@@ -2,7 +2,7 @@
 # Configures the Apache HTTP server with sane defaults.
 
 - name: Disable default Apache site
-  command: a2dissite 000-default removes=/etc/apache2/sites-enabled/000-default
+  command: a2dissite 000-default removes=/etc/apache2/sites-enabled/000-default.conf
   notify: restart apache
 
 - name: Enable Apache headers module

--- a/roles/monitoring/files/etc_apache2_sites-available_00-status.conf
+++ b/roles/monitoring/files/etc_apache2_sites-available_00-status.conf
@@ -1,6 +1,6 @@
 # This needs to be the first configured virtualhost on port 80 so that
 # requests to http://localhost hit this rather than any other vhost
-<VirtualHost *:80>
+<VirtualHost 127.0.0.1:80>
   <Location />
     SetHandler server-status
     Require ip 127.0.0.1


### PR DESCRIPTION
Documentation for DirectoryIndex and Options on apache2 claim to be valid in VirtualHosts, but this never actually took effect for me until I put it in the Directory block. Clarifying the listener for monit was also required, and should be safer for future configuration changes.

In jessie, apache uses `.conf`` name endings.

