### PR TITLE
Bump checkrbl version to stop using emailbasura

### DIFF
--- a/roles/mailserver/tasks/checkrbl.yml
+++ b/roles/mailserver/tasks/checkrbl.yml
@@ -1,8 +1,8 @@
 - name: Download check-rbl
   get_url: >-
-    url=https://raw.githubusercontent.com/lukecyca/check-rbl/920f503f05e0aad785f01cb9ab356e239fee4924/check-rbl.pl
+    url=https://raw.githubusercontent.com/lukecyca/check-rbl/479c1d5aa57543ba4c495ef06028fd9092ffdf43/check-rbl.pl
     dest=/opt/check-rbl.pl
-    sha256sum=1f2a805fe8ba4d9918fafdef2c4d116bb2a92701c9fb790a85b73ffd5a4f4800
+    sha256sum=0968ea1991b500a2bb39b4aefb05c6bf42a62994774f2c46de5d426d5094508b
 
 - name: Install nightly check-rbl cronjob
   cron: name="check-rbl" hour="2" minute="0" job="perl /opt/check-rbl.pl -i {{ ansible_default_ipv4.address }}"


### PR DESCRIPTION
The blacklist bl.emailbasura.org is not available anymore and has been removed from check-rbl.
This pull request just updates to the latest version of https://github.com/lukecyca/check-rbl.
(Similar to #340).