### PR TITLE
Ubuntu 20.04 (focal) support

### DIFF
--- a/roles/common/tasks/google_auth.yml
+++ b/roles/common/tasks/google_auth.yml
@@ -5,8 +5,6 @@
   apt: pkg={{ item }} state=present
   with_items:
     - libpam-google-authenticator
-    - libpam0g-dev
-    - libqrencode3
   tags:
     - dependencies
 

--- a/roles/common/tasks/letsencrypt.yml
+++ b/roles/common/tasks/letsencrypt.yml
@@ -19,8 +19,29 @@
     owner=root
     group=root
 
+- name: Install letsencrypt python dependencies
+  when: ansible_facts['distribution_release'] == 'focal'
+  apt: pkg={{ item }} state=present
+  with_items:
+    - python-is-python3
+    - python3-venv
+    - python3-virtualenv
+    - python3-dev
+    - libssl-dev
+    - gcc
+    - openssl
+    - libffi-dev
+    - ca-certificates
+
 - name: Install LetsEncrypt package dependencies
+  when: ansible_facts['distribution_release'] != 'focal'
   command: /root/letsencrypt/letsencrypt-auto --help
+  register: le_deps_result
+  changed_when: "'Bootstrapping dependencies' in le_deps_result.stdout"
+
+- name: Install LetsEncrypt package dependencies
+  when: ansible_facts['distribution_release'] == 'focal'
+  command: /root/letsencrypt/letsencrypt-auto --help --no-bootstrap
   register: le_deps_result
   changed_when: "'Bootstrapping dependencies' in le_deps_result.stdout"
 

--- a/roles/common/tasks/postgres.yml
+++ b/roles/common/tasks/postgres.yml
@@ -3,9 +3,19 @@
 
 - name: Install Postgres
   apt: pkg={{ item }} state=present
+  when: ansible_facts['distribution_release'] != 'focal'
   with_items:
     - postgresql
     - python-psycopg2
+  tags:
+    - dependencies
+
+- name: Install Postgres
+  apt: pkg={{ item }} state=present
+  when: ansible_facts['distribution_release'] == 'focal'
+  with_items:
+    - postgresql
+    - python3-psycopg2
   tags:
     - dependencies
 

--- a/roles/mailserver/tasks/postfix.yml
+++ b/roles/mailserver/tasks/postfix.yml
@@ -1,4 +1,5 @@
 - name: Install Postfix and related packages
+  when: ansible_facts['distribution_release'] != 'focal'
   apt: pkg={{ item }} state=present
   with_items:
     - libsasl2-modules
@@ -7,6 +8,20 @@
     - postfix-pgsql
     - postgrey
     - python-psycopg2
+    - sasl2-bin
+  tags:
+    - dependencies
+ 
+- name: Install Postfix and related packages
+  when: ansible_facts['distribution_release'] == 'focal'
+  apt: pkg={{ item }} state=present
+  with_items:
+    - libsasl2-modules
+    - postfix
+    - postfix-pcre
+    - postfix-pgsql
+    - postgrey
+    - python3-psycopg2
     - sasl2-bin
   tags:
     - dependencies

--- a/roles/mailserver/tasks/rspamd.yml
+++ b/roles/mailserver/tasks/rspamd.yml
@@ -3,25 +3,33 @@
 
 - name: Ensure repository key for Rspamd is in place
   apt_key: url=https://rspamd.com/apt-stable/gpg.key state=present
-  when: ansible_architecture != "armv7l"
+  when: 
+    - ansible_architecture != "armv7l"
+    - ansible_facts['distribution_release'] != 'focal'
   tags:
     - dependencies
 
 - name: Ensure yunohost repository key for Rspamd is in place for ARM
   apt_key: url=http://repo.yunohost.org/debian/yunohost.asc state=present
-  when: ansible_architecture == "armv7l"
+  when: 
+    - ansible_architecture == "armv7l"
+    - ansible_facts['distribution_release'] != 'focal'
   tags:
     - dependencies
 
 - name: Add Rspamd repository
   apt_repository: repo="deb https://rspamd.com/apt-stable/ {{ ansible_distribution_release }} main"
-  when: ansible_architecture != "armv7l"
+  when: 
+    - ansible_architecture != "armv7l"
+    - ansible_facts['distribution_release'] != 'focal'
   tags:
     - dependencies
 
 - name: Add yunohost Rspamd repository for ARM
   apt_repository: repo="deb http://repo.yunohost.org/debian {{ ansible_distribution_release }} stable"
-  when: ansible_architecture == "armv7l"
+  when: 
+    - ansible_architecture == "armv7l"
+    - ansible_facts['distribution_release'] != 'focal'
   tags:
     - dependencies
 

--- a/roles/mailserver/tasks/solr.yml
+++ b/roles/mailserver/tasks/solr.yml
@@ -10,7 +10,13 @@
   copy: src=solr-schema.xml dest=/etc/solr/conf/schema.xml group=root owner=root
 
 - name: Copy tweaked Tomcat config file into place
+  when: ansible_facts['distribution_release'] != 'focal'
   copy: src=etc_tomcat7_server.xml dest=/etc/tomcat7/server.xml group=tomcat7 owner=root
+  notify: restart solr
+
+- name: Copy tweaked Tomcat config file into place
+  when: ansible_facts['distribution_release'] == 'focal'
+  copy: src=etc_tomcat7_server.xml dest=/etc/tomcat9/server.xml group=tomcat owner=root
   notify: restart solr
 
 - name: Copy tweaked Solr config file into place
@@ -18,5 +24,5 @@
   notify: restart solr
 
 - name: Create Solr index directory
-  file: state=directory path=/decrypted/solr group=tomcat7 owner=tomcat7
+  file: state=directory path=/decrypted/solr group=tomcat owner=tomcat
   notify: restart solr

--- a/roles/mailserver/tasks/z-push.yml
+++ b/roles/mailserver/tasks/z-push.yml
@@ -1,10 +1,22 @@
 - name: Install required packages for z-push
+  when: ansible_facts['distribution_release'] != 'focal'
   apt: pkg={{ item }} state=present
   with_items:
     - php-soap
     - php5
     - php5-cli
     - php5-imap
+  tags:
+    - dependencies
+
+- name: Install required packages for z-push
+  when: ansible_facts['distribution_release'] == 'focal'
+  apt: pkg={{ item }} state=present
+  with_items:
+    - php-soap
+    - php
+    - php-cli
+    - php-imap
   tags:
     - dependencies
 

--- a/roles/tarsnap/tasks/tarsnap.yml
+++ b/roles/tarsnap/tasks/tarsnap.yml
@@ -7,7 +7,9 @@
     - dependencies
 
 - name: Install dependencies for Tarsnap
-  when: tarsnap_installed is failed
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] != 'focal'
   apt: pkg={{ item }} state=present
   with_items:
     - e2fslibs-dev
@@ -17,59 +19,102 @@
     - dependencies
 
 - name: Download the current tarsnap code signing key
-  when: tarsnap_installed is failed
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] != 'focal'
   get_url:
     url=https://www.tarsnap.com/tarsnap-signing-key.asc
     dest=/root/tarsnap-signing-key.asc
 
 - name: Add the tarsnap code signing key to your list of keys
-  when: tarsnap_installed is failed
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] != 'focal'
   command:
     gpg --import tarsnap-signing-key.asc
     chdir=/root/
 
 - name: Download tarsnap SHA file
-  when: tarsnap_installed is failed
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] != 'focal'
   get_url:
     url="https://www.tarsnap.com/download/tarsnap-sigs-{{ tarsnap_version }}.asc"
     dest="/root/tarsnap-sigs-{{ tarsnap_version }}.asc"
 
 - name: Make the command that gets the current SHA
-  when: tarsnap_installed is failed
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] != 'focal'
   template:
     src=getSha.sh
     dest=/root/getSha.sh
     mode=0755
 
 - name: Get the SHA256sum for this tarsnap release
-  when: tarsnap_installed is failed
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] != 'focal'
   command:
     ./getSha.sh
     chdir=/root
   register: tarsnap_sha
 
 - name: Download Tarsnap source
-  when: tarsnap_installed is failed
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] != 'focal'
   get_url:
     url="https://www.tarsnap.com/download/tarsnap-autoconf-{{ tarsnap_version }}.tgz"
     dest="/root/tarsnap-autoconf-{{ tarsnap_version }}.tgz"
     sha256sum={{ tarsnap_sha.stdout_lines[0] }}
 
 - name: Decompress Tarsnap source
-  when: tarsnap_installed is failed
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] != 'focal'
   unarchive: src=/root/tarsnap-autoconf-{{ tarsnap_version }}.tgz
              dest=/root copy=no
              creates=/root/tarsnap-autoconf-{{ tarsnap_version }}/COPYING
 
 - name: Configure Tarsnap for local build
-  when: tarsnap_installed is failed
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] != 'focal'
   command: >-
     ./configure chdir=/root/tarsnap-autoconf-{{ tarsnap_version }}
     creates=/root/tarsnap-autoconf-{{ tarsnap_version }}/Makefile
 
 - name: Build and install Tarsnap
-  when: tarsnap_installed is failed
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] != 'focal'
   command: make all install clean chdir=/root/tarsnap-autoconf-{{ tarsnap_version }} creates=/usr/local/bin/tarsnap
+
+- name: Install Tarsnap repo key
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] == 'focal'
+  apt_key:
+    url: https://pkg.tarsnap.com/tarsnap-deb-packaging-key.asc
+    id: FC72A10BF6B692AA
+    state: present
+
+- name: Install Tarsnap repo
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] == 'focal'
+  apt_repository:
+    repo: deb http://pkg.tarsnap.com/deb/focal ./
+    state: present
+
+- name: Install Tarsnap repo
+  when: 
+    - tarsnap_installed is failed
+    - ansible_facts['distribution_release'] == 'focal'
+  apt: pkg={{ item }} state=present
+  with_items:
+    - tarsnap
 
 - name: Copy Tarsnap key file into place
   copy: src=decrypted_tarsnap.key dest=/decrypted/tarsnap.key owner=root group=root mode="0600" force=no

--- a/roles/webmail/tasks/roundcube.yml
+++ b/roles/webmail/tasks/roundcube.yml
@@ -3,6 +3,7 @@
   register: roundcube_config
 
 - name: Install roundcube dependencies
+  when: ansible_facts['distribution_release'] != 'focal'
   apt: pkg={{ item }} state=present
   with_items:
     - php5
@@ -14,6 +15,39 @@
     - php5-curl
     - aspell
     - aspell-en
+    - php-mbstring
+  tags:
+    - dependencies
+
+- name: Install roundcube dependencies
+  when: ansible_facts['distribution_release'] == 'focal'
+  apt: pkg={{ item }} state=present
+  with_items:
+    - php
+    - php-sqlite3
+    - php-gd
+    - php-pspell
+    - php-intl
+    - php-curl
+    - aspell
+    - aspell-en
+    - php-mbstring
+  tags:
+    - dependencies
+
+- name: Install mbcrypt pear
+  when: ansible_facts['distribution_release'] == 'focal'
+  pear:
+    name: pecl/mcrypt
+    state: present
+  tags:
+    - dependencies
+
+- name: Register mcrypt module
+  when: ansible_facts['distribution_release'] == 'focal'
+  command:
+    cmd: 'echo extension=mcrypt.so > /etc/php/7.4/mods-available/mcrypt.ini; phpenmod mcrypt'
+    creates: /etc/php/7.4/apache2/conf.d/20-mcrypt.ini
   tags:
     - dependencies
 


### PR DESCRIPTION
Mainly python3 pains.

Using Ubuntu rspamd because there is no upstream repo.

This partly fixes https://github.com/sovereign/sovereign/issues/789

Untested modules, those will likely still fail
    - news
    - git
    - readlater
    - blog
    - ircbouncer
    - xmpp
    - owncloud
    - vpn