### PR TITLE
XMPP compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ Create `A` or `CNAME` records which point to your server's IP address:
 * `news.example.com` (for Selfoss)
 * `cloud.example.com` (for ownCloud)
 * `git.example.com` (for cgit)
-* `muc.example.com` (for XMPP Multi User Chat)
-* `proxy.example.com` (for XMPP SOCKS5)
+* `channels.example.com` (for XMPP Multi User Chat)
 * `upload.example.com` (for XMPP File Upload)
 
 Create `SRV` records for XMPP:

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ Create `A` or `CNAME` records which point to your server's IP address:
 * `news.example.com` (for Selfoss)
 * `cloud.example.com` (for ownCloud)
 * `git.example.com` (for cgit)
+* `muc.example.com` (for XMPP Multi User Chat)
+* `proxy.example.com` (for XMPP SOCKS5)
+* `upload.example.com` (for XMPP File Upload)
+
+Create `SRV` records for XMPP:
+
+* `_xmpp-client._tcp.example.com` -> `0 5 5222 example.com` (`{priority: 0, weight: 5, port: 5222}`)
+* `_xmpps-client._tcp.example.com` -> `0 5 5223 example.com` (`{priority: 0, weight: 5, port: 5223}`)
+* `_xmpp-server._tcp.example.com` -> `0 5 5269 example.com` (`{priority: 0, weight: 5, port: 5269}`)
 
 ### 6. Run the Ansible Playbooks
 

--- a/roles/common/files/letsencrypt-gencert
+++ b/roles/common/files/letsencrypt-gencert
@@ -1,6 +1,6 @@
 #!/bin/bash
 d="$1"
-for i in www mail autoconfig read news cloud git; do
+for i in www mail autoconfig read news cloud git channels upload; do
   if (getent hosts $i.$1 > /dev/null); then
     d="$d,$i.$1";
   fi

--- a/roles/xmpp/defaults/main.yml
+++ b/roles/xmpp/defaults/main.yml
@@ -3,5 +3,7 @@ prosody_virtual_domain: "{{ domain }}"
 prosody_accounts: []
 prosody_db_username: prosody
 prosody_db_database: prosody
+prosody_muc_default_language: en
+prosody_muc_name: "The {{ domain }} multi user chat"
 
 coturn_port: "5349"

--- a/roles/xmpp/defaults/main.yml
+++ b/roles/xmpp/defaults/main.yml
@@ -1,3 +1,7 @@
 prosody_admin: "{{ admin_email }}"
 prosody_virtual_domain: "{{ domain }}"
 prosody_accounts: []
+prosody_db_username: prosody
+prosody_db_database: prosody
+
+coturn_port: "5349"

--- a/roles/xmpp/handlers/main.yml
+++ b/roles/xmpp/handlers/main.yml
@@ -1,2 +1,13 @@
 - name: restart prosody
-  service: name=prosody state=restarted
+  systemd:
+    name: prosody
+    daemon_reload: yes
+    enabled: yes
+    state: restarted
+
+- name: restart coturn
+  systemd:
+    name: coturn
+    daemon_reload: yes
+    enabled: yes
+    state: restarted

--- a/roles/xmpp/tasks/coturn.yml
+++ b/roles/xmpp/tasks/coturn.yml
@@ -1,0 +1,24 @@
+- name: Install coturn
+  apt:
+    pkg: ['coturn']
+    update_cache: yes
+  tags:
+    - dependencies
+
+- name: Configure coturn
+  template:
+    src: etc_turnserver.conf.j2
+    dest: /etc/turnserver.conf
+    group: root
+    owner: root
+
+- name: Set firewall rules for coturn
+  ufw:
+    rule: allow
+    port: "{{ coturn_port }}"
+    proto: udp
+  tags: ufw
+
+- name: Restart coturn service
+  command: /bin/true
+  notify: restart coturn

--- a/roles/xmpp/tasks/main.yml
+++ b/roles/xmpp/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 # Provides the Prosody Jabber/XMPP server.
 
-- import_tasks: prosody.yml
-  tags: prosody
+- include: coturn.yml tags=prosody
+- include: prosody.yml tags=prosody

--- a/roles/xmpp/tasks/prosody.yml
+++ b/roles/xmpp/tasks/prosody.yml
@@ -1,33 +1,83 @@
 - name: Ensure repository key for Prosody is in place
-  apt_key: url=https://prosody.im/files/prosody-debian-packages.key state=present
+  apt_key:
+    url: https://prosody.im/files/prosody-debian-packages.key
+    state: present
   tags:
     - dependencies
 
 - name: Add Prosody repository
-  apt_repository: repo="deb http://packages.prosody.im/debian {{ ansible_distribution_release }} main"
+  apt_repository:
+    repo: "deb http://packages.prosody.im/debian {{ ansible_distribution_release }} main"
   tags:
     - dependencies
 
 - name: Install Prosody and dependencies from official repository
-  apt: pkg={{ item }} update_cache=yes
-  with_items:
-    - prosody
-    - lua-sec
+  apt:
+    pkg: ['prosody', 'lua-sec', 'lua-zlib', 'lua-event', 'lua-dbi-postgresql', 'mercurial']
+    update_cache: yes
   tags:
     - dependencies
 
 - name: Add prosody user to ssl-cert group
-  user: name=prosody group=ssl-cert
+  user:
+    name: prosody
+    group: ssl-cert
+    system: yes
+    shell: /usr/sbin/nologin
+
+- name: Create postgres user for prosody
+  postgresql_user:
+    login_host: localhost
+    login_user: "{{ db_admin_username }}"
+    login_password: "{{ db_admin_password }}"
+    name: "{{ prosody_db_username }}"
+    password: "{{ prosody_db_password }}"
+    state: present
+
+- name: Create database for prosody
+  postgresql_db:
+    login_host: localhost
+    login_user: "{{ db_admin_username }}"
+    login_password: "{{ db_admin_password }}"
+    name: "{{ prosody_db_database }}"
+    state: present
+    owner: "{{ prosody_db_username }}"
 
 - name: Add cert postrenew task
-  copy: src=etc_letsencrypt_postrenew_prosody.sh dest=/etc/letsencrypt/postrenew/prosody.sh mode=0755
+  copy:
+    src: etc_letsencrypt_postrenew_prosody.sh
+    dest: /etc/letsencrypt/postrenew/prosody.sh
+    mode: 0755
 
 - name: Create Prosody data directory
   file: state=directory path=/decrypted/prosody owner=prosody group=prosody
 
+- name: Clone Prosody community modules
+  hg:
+    repo: "https://hg.prosody.im/prosody-modules"
+    revision: default
+    dest: "/opt/prosody-modules"
+    purge: yes
+    update: yes
+
 - name: Configure Prosody
-  template: src=prosody.cfg.lua.j2 dest=/etc/prosody/prosody.cfg.lua group=prosody owner=root mode=0644
-  notify: restart prosody
+  template:
+    src: prosody.cfg.lua.j2
+    dest: /etc/prosody/prosody.cfg.lua
+    group: prosody
+    owner: prosody
+
+- name: Delete the default cert config
+  file:
+    path: /etc/prosody/certs
+    state: absent
+
+- name: Set prosody configuration permissions
+  file:
+    path: /etc/prosody
+    owner: prosody
+    group: prosody
+    recurse: yes
 
 - name: Create Prosody accounts
   command: prosodyctl register {{ item.name }} {{ prosody_virtual_domain }} "{{ item.password }}"
@@ -35,9 +85,18 @@
   tags:
     - skip_ansible_lint
 
+- name: Restart Prosody service
+  command: /bin/true
+  notify: restart prosody
+
 - name: Set firewall rules for Prosody
-  ufw: rule=allow port={{ item }} proto=tcp
+  ufw:
+    rule: allow
+    port: "{{ item }}"
+    proto: tcp
   with_items:
-    - 5222  # xmpp c2s
-    - 5269  # xmpp s2s
+    - "5222"  # xmpp c2s
+    - "5223"  # xmpp legacy c2s
+    - "5269"  # xmpp s2s
+    - "5000"  # proxy
   tags: ufw

--- a/roles/xmpp/tasks/prosody.yml
+++ b/roles/xmpp/tasks/prosody.yml
@@ -100,3 +100,10 @@
     - "5269"  # xmpp s2s
     - "5000"  # proxy
   tags: ufw
+
+- name: Configure the Apache HTTP server for XMPP
+  template: src=etc_apache2_sites-available_xmpp.j2 dest=/etc/apache2/sites-available/xmpp.conf group=root owner=root
+
+- name: Enable XMPP site
+  command: a2ensite xmpp.conf creates=/etc/apache2/sites-enabled/xmpp.conf
+  notify: restart apache

--- a/roles/xmpp/templates/etc_apache2_sites-available_xmpp.j2
+++ b/roles/xmpp/templates/etc_apache2_sites-available_xmpp.j2
@@ -1,0 +1,25 @@
+<VirtualHost *:80>
+    ServerName {{ domain }}
+
+    Redirect permanent / https://{{ domain }}/
+</VirtualHost>
+
+
+<VirtualHost *:443>
+    ServerName {{ domain }}
+    SSLEngine On
+
+    # start of xmpp config
+    <Location /http-bind>
+      Order allow,deny
+      Allow from all
+    </Location>
+    RewriteEngine On
+    RewriteRule ^/http-bind$ http://localhost:5280/http-bind [P,L]
+
+    DocumentRoot            "/var/www/{{ domain }}"
+    DirectoryIndex          index.html
+    Options                 -Indexes
+
+    HostnameLookups         Off
+</VirtualHost>

--- a/roles/xmpp/templates/etc_turnserver.conf.j2
+++ b/roles/xmpp/templates/etc_turnserver.conf.j2
@@ -1,0 +1,26 @@
+tls-listening-port={{ coturn_port }}
+lt-cred-mech
+fingerprint
+stale-nonce
+use-auth-secret
+static-auth-secret={{ coturn_secret }}
+server-name={{ domain }}
+realm={{ domain }}
+cert=/etc/letsencrypt/live/{{ domain }}/fullchain.pem
+pkey=/etc/letsencrypt/live/{{ domain }}/privkey.pem
+no-stdout-log
+log-file=/var/log/turnserver/turn.log
+simple-log
+pidfile=”/var/run/turnserver/turnserver.pid”
+mobility
+no-tlsv1
+no-tlsv1_1
+no-tcp-relay
+user-quota=12
+total-quota=1200
+denied-peer-ip=10.0.0.0-10.255.255.255
+denied-peer-ip=192.168.0.0-192.168.255.255
+denied-peer-ip=172.16.0.0-172.31.255.255
+no-loopback-peers
+no-multicast-peers
+no-tcp

--- a/roles/xmpp/templates/prosody.cfg.lua.j2
+++ b/roles/xmpp/templates/prosody.cfg.lua.j2
@@ -73,7 +73,7 @@ modules_enabled = {
 		--"admin_telnet"; -- Opens telnet console interface on localhost port 5582
 
 	-- HTTP modules
-		--"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
+		"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
 		--"http_files"; -- Serve static files from a directory over HTTP
 
 	-- Other specific functionality

--- a/roles/xmpp/templates/prosody.cfg.lua.j2
+++ b/roles/xmpp/templates/prosody.cfg.lua.j2
@@ -59,13 +59,11 @@ modules_enabled = {
 		"turncredentials"; -- STUN/TURN
 
     -- Required for Conversations
-        "proxy65";
         "blocklist";
         "smacks";
         "carbons";
         "mam";
         "csi";
-        "http_upload";
         "cloud_notify";
 
 	-- Admin interfaces
@@ -129,6 +127,8 @@ log = {
 	"*syslog";
 }
 
+-- NB: Those addresses will be publicly visible.
+-- Make sure that these exist in group_vars/sovereign.
 contact_info = {
   abuse = { "mailto:abuse@{{ domain }}" };
   admin = { "mailto:webmaster@{{ domain }}", "xmpp:{{ main_user_name }}@{{ domain }}" };
@@ -148,7 +148,7 @@ pidfile = "/var/run/prosody/prosody.pid"
 
 VirtualHost "{{ prosody_virtual_domain }}"
 
-Component "muc.{{ domain }}" "muc"
+Component "channels.{{ domain }}" "muc"
     modules_enabled = {
       "muc_mam";
       "muc_log";
@@ -156,19 +156,16 @@ Component "muc.{{ domain }}" "muc"
     }
     muc_log_by_default = true;
     max_history_messages = 20;
-    name = "The {{ domain }} multi user chat";
+    name = "{{ prosody_muc_name }}";
     muc_room_default_change_subject = true;
     muc_room_default_history_length = 20;
-    muc_room_default_language = "en";
+    muc_room_default_language = "{{ prosody_muc_default_language }}";
     restrict_room_creation = "local";
 
 Component "proxy.{{ domain }}" "proxy65"
-    proxy65_address = "proxy.{{ domain }}";
+    proxy65_address = "{{ domain }}";
     proxy65_acl = { "{{ domain }}" };
 
 Component "upload.{{ domain }}" "http_upload"
-    http_upload_file_size_limit = 52428800 -- 50MB
-    http_max_content_size = 52428800 -- 50MB
-    modules_enabled = {
-        "http";
-    }
+    http_upload_file_size_limit = 52428800; -- 50MB
+    http_max_content_size = 52428800; -- 50MB

--- a/roles/xmpp/templates/prosody.cfg.lua.j2
+++ b/roles/xmpp/templates/prosody.cfg.lua.j2
@@ -25,6 +25,8 @@ admins = { "{{ prosody_admin }}" }
 -- For more information see: http://prosody.im/doc/libevent
 --use_libevent = true;
 
+plugin_paths = { "/opt/prosody-modules" }
+
 -- This is the list of modules Prosody will load on startup.
 -- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
 -- Documentation on modules can be found at: http://prosody.im/doc/modules
@@ -40,19 +42,31 @@ modules_enabled = {
 
 	-- Not essential, but recommended
 		"private"; -- Private XML storage (for room bookmarks, etc.)
-		"vcard"; -- Allow users to set vCards
+	    "vcard_legacy"; -- User Avatar to vCard-Based Avatars Conversion
+	    "bookmarks"; -- Bookmarks Conversion
+	    "server_contact_info"; -- Provide Contact Information
 
 	-- These are commented by default as they have a performance impact
-		"privacy"; -- Support privacy lists
-		--"compression"; -- Stream compression (requires the lua-zlib package installed)
+		"privacy_lists"; -- Support privacy lists
 
 	-- Nice to have
 		"version"; -- Replies to server version requests
 		"uptime"; -- Report how long server has been running
 		"time"; -- Let others know the time here on this server
 		"ping"; -- Replies to XMPP pings with pongs
-		-- "pep"; -- Enables users to publish their mood, activity, playing music and more
+		"pep"; -- Enables users to publish their mood, activity, playing music and more
 		"register"; -- Allow users to register on this server using a client and change passwords
+		"turncredentials"; -- STUN/TURN
+
+    -- Required for Conversations
+        "proxy65";
+        "blocklist";
+        "smacks";
+        "carbons";
+        "mam";
+        "csi";
+        "http_upload";
+        "cloud_notify";
 
 	-- Admin interfaces
 		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
@@ -63,10 +77,10 @@ modules_enabled = {
 		--"http_files"; -- Serve static files from a directory over HTTP
 
 	-- Other specific functionality
-		--"groups"; -- Shared roster support
-		--"announce"; -- Send announcement to all online users
+		"groups"; -- Shared roster support
+		"announce"; -- Send announcement to all online users
 		--"welcome"; -- Welcome users who register accounts
-		--"watchregistrations"; -- Alert admins of registrations
+		"watchregistrations"; -- Alert admins of registrations
 		--"motd"; -- Send a message to users when they log in
 		--"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
 };
@@ -82,94 +96,79 @@ modules_disabled = {
 -- Disable account creation by default, for security
 -- For more information see http://prosody.im/doc/creating_accounts
 allow_registration = false;
+data_path = "/decrypted/prosody"
+authentication = "internal_hashed"
+use_libevent = true;
+cross_domain_bosh = true
+consider_bosh_secure = true
+http_external_url = "https://{{ prosody_virtual_domain }}/"
+trusted_proxies = { "127.0.0.1", "::1"}
+
+http_ports = { 5280 }
+http_interfaces = { "127.0.0.1", "::1" }
+https_ports = { 5281 }
+https_interfaces = { "127.0.0.1", "::1" }
+
+c2s_require_encryption = true
+s2s_secure_auth = true
+--s2s_insecure_domains = { "gmail.com" }
 
 -- These are the SSL/TLS-related settings. If you don't want
 -- to use SSL/TLS, you may comment or remove this
+legacy_ssl_ports = { 5223 }
 ssl = {
 	key = "/etc/letsencrypt/live/{{ domain }}/privkey.pem";
 	certificate = "/etc/letsencrypt/live/{{ domain }}/fullchain.pem";
+	protocol = "tlsv1_2+";
+	ciphers = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!PSK:!SRP:!3DES:!aNULL";
 }
 
--- Force clients to use encrypted connections? This option will
--- prevent clients from authenticating unless they are using encryption.
-
-c2s_require_encryption = true
-
--- Force certificate authentication for server-to-server connections?
--- This provides ideal security, but requires servers you communicate
--- with to support encryption AND present valid, trusted certificates.
--- NOTE: Your version of LuaSec must support certificate verification!
--- For more information see http://prosody.im/doc/s2s#security
-
-s2s_secure_auth = false
-
--- Many servers don't support encryption or have invalid or self-signed
--- certificates. You can list domains here that will not be required to
--- authenticate using certificates. They will be authenticated using DNS.
-
---s2s_insecure_domains = { "gmail.com" }
-
--- Even if you leave s2s_secure_auth disabled, you can still require valid
--- certificates for some domains by specifying a list here.
-
---s2s_secure_domains = { "jabber.org" }
-
--- Required for init scripts and prosodyctl
-pidfile = "/var/run/prosody/prosody.pid"
-
--- Select the authentication backend to use. The 'internal' providers
--- use Prosody's configured data storage to store the authentication data.
--- To allow Prosody to offer secure authentication mechanisms to clients, the
--- default provider stores passwords in plaintext. If you do not trust your
--- server please see http://prosody.im/doc/modules/mod_auth_internal_hashed
--- for information about using the hashed backend.
-
-authentication = "internal_hashed"
-
--- Select the storage backend to use. By default Prosody uses flat files
--- in its configured data directory, but it also supports more backends
--- through modules. An "sql" backend is included by default, but requires
--- additional dependencies. See http://prosody.im/doc/storage for more info.
-
---storage = "sql" -- Default is "internal"
-
--- For the "sql" backend, you can uncomment *one* of the below to configure:
---sql = { driver = "SQLite3", database = "prosody.sqlite" } -- Default. 'database' is the filename.
---sql = { driver = "MySQL", database = "prosody", username = "prosody", password = "secret", host = "localhost" }
---sql = { driver = "PostgreSQL", database = "prosody", username = "prosody", password = "secret", host = "localhost" }
-
--- Logging configuration
--- For advanced logging see http://prosody.im/doc/logging
 log = {
 	info = "/var/log/prosody/prosody.log"; -- Change 'info' to 'debug' for verbose logging
 	error = "/var/log/prosody/prosody.err";
 	"*syslog";
 }
 
-data_path = "/decrypted/prosody"
+contact_info = {
+  abuse = { "mailto:abuse@{{ domain }}" };
+  admin = { "mailto:webmaster@{{ domain }}", "xmpp:{{ main_user_name }}@{{ domain }}" };
+  feedback = { "mailto:webmaster@{{ domain }}" };
+  security = { "mailto:abuse@{{ domain }}" };
+  support = { "mailto:webmaster@{{ domain }}" };
+};
 
------------ Virtual hosts -----------
--- You need to add a VirtualHost entry for each domain you wish Prosody to serve.
--- Settings under each VirtualHost entry apply *only* to that host.
+turncredentials_host = "{{ prosody_virtual_domain }}"
+turncredentials_secret = "{{ coturn_secret }}"
+
+storage = "sql"
+sql = { driver = "PostgreSQL", database = "{{ prosody_db_database }}", username = "{{ prosody_db_username }}", password = "{{ prosody_db_password }}", host = "localhost" }
+
+-- Required for init scripts and prosodyctl
+pidfile = "/var/run/prosody/prosody.pid"
 
 VirtualHost "{{ prosody_virtual_domain }}"
 
------- Components ------
--- You can specify components to add hosts that provide special services,
--- like multi-user conferences, and transports.
--- For more information on components, see http://prosody.im/doc/components
+Component "muc.{{ domain }}" "muc"
+    modules_enabled = {
+      "muc_mam";
+      "muc_log";
+      "vcard_muc"; -- vCard-Based Avatar (MUC)
+    }
+    muc_log_by_default = true;
+    max_history_messages = 20;
+    name = "The {{ domain }} multi user chat";
+    muc_room_default_change_subject = true;
+    muc_room_default_history_length = 20;
+    muc_room_default_language = "en";
+    restrict_room_creation = "local";
 
----Set up a MUC (multi-user chat) room server on conference.example.com:
---Component "conference.example.com" "muc"
+Component "proxy.{{ domain }}" "proxy65"
+    proxy65_address = "proxy.{{ domain }}";
+    proxy65_acl = { "{{ domain }}" };
 
--- Set up a SOCKS5 bytestream proxy for server-proxied file tr3ansfers:
---Component "proxy.example.com" "proxy65"
-
----Set up an external component (default component port is 5347)
---
--- External components allow adding various services, such as gateways/
--- transports to other networks like ICQ, MSN and Yahoo. For more info
--- see: http://prosody.im/doc/components#adding_an_external_component
---
---Component "gateway.example.com"
---	component_secret = "password"
+Component "upload.{{ domain }}" "http_upload"
+    http_upload_file_size_limit = 52428800 -- 50MB
+    http_max_content_size = 52428800 -- 50MB
+    modules_enabled = {
+        "http";
+    }

--- a/roles/xmpp/templates/prosody.cfg.lua.j2
+++ b/roles/xmpp/templates/prosody.cfg.lua.j2
@@ -63,7 +63,7 @@ modules_enabled = {
         "smacks";
         "carbons";
         "mam";
-        "csi";
+        "mod_csi_simple";
         "cloud_notify";
 
 	-- Admin interfaces


### PR DESCRIPTION
Hi,

this PR adds the following:
- Postgres as storage backend
- compliance with the checks at https://compliance.conversations.im/ 
    - RFC 6121; Roster Versioning
    - XEP-0153; vCard-Based Avatar (MUC)
    - XEP-0045; Multi-User Chat
    - XEP-0065; SOCKS5 Bytestreams
    - XEP-0115; Entity Capabilities
    - XEP-0160; Best Practices for Offline Messages
    - XEP-0163; Personal Eventing Protocol
    - XEP-0191; Blocking Command
    - XEP-0198; Stream Management
    - XEP-0280; Message Carbons
    - XEP-0313; Message Archive Management
    - XEP-0313; Message Archive Management (MUC)
    - XEP-0352; Client State Indication
    - XEP-0357; Push Notifications
    - XEP-0363; HTTP File Upload
    - XEP-0384; OMEMO Encryption
    - XEP-0398; User Avatar to vCard Avatar Conversion
    - XEP-0411; Bookmarks Conversion
    - XEP-0157; Contact Addresses
    - XEP-0215; External Service Discovery (STUN/TURN)
