### PR TITLE
Fix  active sieve showing up as mailbox dir

### DIFF
--- a/roles/mailserver/files/etc_dovecot_conf.d_90-sieve.conf
+++ b/roles/mailserver/files/etc_dovecot_conf.d_90-sieve.conf
@@ -1,5 +1,5 @@
 plugin {
-  sieve = ~/.dovecot.sieve
+  sieve = ~/sieve/.dovecot.sieve
   sieve_dir = ~/sieve
   sieve_before = /etc/dovecot/sieve/before.d
 }


### PR DESCRIPTION
After fixing #815, the active sieve is showing up as a mailbox folder in roundcube.

This is happening because the mailboxes are stored like `${maildir}/.INBOX.foldername` and the active sieve is located at `${maildir}/.dovecot.sieve`. So there will be a `dovecot/sieve` folder showing up in IMAP clients.

This PR fixes that by moving the active sieve to `${maildir}/sieve/.dovecot.sieve`.

I have tested this for two days now and it's working like a charm on my setup. The active sieve file also doesn't show up as a filter group in roundcube.